### PR TITLE
fix(codex-gate): the review gate made the review protocol uncommittable (#533)

### DIFF
--- a/SDLC.md
+++ b/SDLC.md
@@ -46,7 +46,7 @@ This repository uses the SDLC Harness to enforce:
 |------|---------|---------|
 | `sdlc-prompt-check.sh` | Every prompt | SDLC baseline reminder, claude-setup-wizard redirect when SDLC.md/TESTING.md missing |
 | `tdd-pretool-check.sh` | Before Write/Edit/MultiEdit | Blocks (exit 2) implementation writes to `src/**` unless a test file was touched earlier this session. This repo's own gate is scoped to `hooks/`, `cli/`, `.github/workflows/` via `SDLC_TDD_SRC_PATTERN` (no `src/` dir here) |
-| `codex-gate-check.sh` | Before `git commit` (Bash) | Blocks (exit 2) commits without a REVIEWED/CERTIFIED `.reviews/handoff.json`, or with a stale (`commit_sha` mismatch) certification |
+| `codex-gate-check.sh` | Before `git commit` (Bash) | Blocks (exit 2) commits without a `.reviews/handoff.json`, with a stale (`commit_sha` mismatch) certification, or with an unrecognised status. An **in-flight** status (`PENDING_REVIEW`/`PENDING_RECHECK`) may commit, but only on a branch the hook can prove is not the default one — so a review round has an immutable SHA to read instead of a live tree (#533) |
 | `instructions-loaded-check.sh` | Session start | Wizard-version + CC-version staleness nudges, cross-model-review staleness check, autocompact compound-misconfig check, dual-channel-install check |
 | `model-effort-check.sh` | Session start | Nudges upgrade when effort/model is behind recommended |
 | `precompact-seam-check.sh` | Before manual `/compact` | Blocks compact mid-rebase/merge/cherry-pick (requires CC v2.1.105+) |

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -23,7 +23,7 @@ source "$HOOK_DIR/_find-sdlc-root.sh"
 
 TOOL_INPUT=$(read_stdin_bounded) || {
     # Fail CLOSED: unreadable stdin must not become an allow (#491 P0).
-    echo "CROSS-MODEL REVIEW GATE: could not read hook input within ${SDLC_HOOK_STDIN_TIMEOUT:-5}s. Refusing to allow an unverified command. Set CODEX_GATE_SKIP=1 to bypass with justification." >&2
+    echo "CROSS-MODEL REVIEW GATE: could not read hook input within ${SDLC_HOOK_STDIN_TIMEOUT:-5}s. Refusing to allow an unverified command. Human override: relaunch Claude Code with CODEX_GATE_SKIP=1 in its environment — this hook runs before your command, so an inline prefix inside a tool call cannot reach it. Your own terminal is unaffected; this is a Claude Code hook, not a git hook." >&2
     exit 2
 }
 
@@ -79,7 +79,7 @@ fi
 REVIEW_FILE=".reviews/handoff.json"
 
 if [ ! -f "$REVIEW_FILE" ]; then
-    echo "CROSS-MODEL REVIEW REQUIRED: No .reviews/handoff.json found. Run Codex cross-model review before committing. Set CODEX_GATE_SKIP=1 to bypass with justification." >&2
+    echo "CROSS-MODEL REVIEW REQUIRED: No .reviews/handoff.json found. Run Codex cross-model review before committing. Human override: relaunch Claude Code with CODEX_GATE_SKIP=1 in its environment — this hook runs before your command, so an inline prefix inside a tool call cannot reach it. Your own terminal is unaffected; this is a Claude Code hook, not a git hook." >&2
     exit 2
 fi
 
@@ -87,7 +87,63 @@ STATUS=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$REVIEW_FILE" \
     | head -1 \
     | sed 's/.*"status"[[:space:]]*:[[:space:]]*"//; s/"$//')
 
+# #533: resolve whether we are on the repo's default branch.
+#
+# The gate's purpose is stopping unreviewed work from reaching the default
+# branch — not stopping work from being SAVED. Blocking every in-flight commit
+# forced reviewers onto a mutable working tree, and during #520 round 18 a
+# reviewer read a tree a mutation harness was concurrently mutating and filed a
+# fully-diagnosed P1 against a defect that existed only in the mutation.
+#
+# Fails STRICT by default: ON_DEFAULT_BRANCH stays 1 unless we can positively
+# prove otherwise. Not a repo, detached HEAD (rev-parse --abbrev-ref prints the
+# literal "HEAD"), main/master, or no trunk-shaped ref anywhere — all strict.
+#
+# refs/remotes/origin/HEAD is a LOCAL ref written by git clone, so this is
+# entirely offline. init.defaultBranch is deliberately NOT consulted: it names
+# the branch for NEW repos, so it can name one this repo never had, which
+# would be a false-lenient source.
+#
+# Two `set -e` landmines, same class as the one memorialised at the top of this
+# file: every git capture needs `|| true` (a non-match exits 1 and kills the
+# script), and the comparison must be a full `if`, never `[ ... ] && VAR=0`
+# (a false test returns 1 and kills the script).
+ON_DEFAULT_BRANCH=1
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+DEFAULT_BRANCH=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+DEFAULT_BRANCH="${DEFAULT_BRANCH#origin/}"
+case "$CURRENT_BRANCH" in
+    ""|HEAD|main|master) ;;
+    *)
+        if [ -n "$DEFAULT_BRANCH" ]; then
+            if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then ON_DEFAULT_BRANCH=0; fi
+        elif git show-ref --verify --quiet refs/heads/main \
+            || git show-ref --verify --quiet refs/heads/master \
+            || git show-ref --verify --quiet refs/remotes/origin/main \
+            || git show-ref --verify --quiet refs/remotes/origin/master; then
+            ON_DEFAULT_BRANCH=0
+        fi
+        ;;
+esac
+
 case "$STATUS" in
+    PENDING_REVIEW|PENDING_RECHECK)
+        # A review round is open. The protocol prescribes exactly these two
+        # statuses for its whole duration, so this is the state in which work
+        # is actually produced. Let it be committed — but only somewhere it
+        # cannot reach the default branch. Round 1 counts as much as round 2:
+        # PENDING_REVIEW is what holds while the FIRST reviewer reads, which
+        # is precisely the configuration that produced the phantom P1.
+        #
+        # commit_sha is deliberately not read here: on this lane it is either
+        # absent by design (never certified) or stale by design (a round is
+        # open). Freshness is lane CERTIFIED/REVIEWED's job, and it keeps it.
+        if [ "$ON_DEFAULT_BRANCH" -eq 0 ]; then
+            exit 0
+        fi
+        echo "CROSS-MODEL REVIEW REQUIRED: status is '$STATUS' (a review round is open) and this looks like the default branch${DEFAULT_BRANCH:+ [$DEFAULT_BRANCH]}${CURRENT_BRANCH:+, current [$CURRENT_BRANCH]}. In-flight work may be committed on a non-default branch so reviewers get an immutable SHA instead of a live tree; reaching the default branch still needs a certification bound to that exact HEAD. Human override: relaunch Claude Code with CODEX_GATE_SKIP=1 in its environment — this hook runs before your command, so an inline prefix inside a tool call cannot reach it." >&2
+        exit 2
+        ;;
     CERTIFIED|REVIEWED)
         # #437: a CERTIFIED/REVIEWED status string alone doesn't mean the
         # certification is still current — commits made after it was issued
@@ -103,13 +159,13 @@ case "$STATUS" in
             | sed 's/.*"commit_sha"[[:space:]]*:[[:space:]]*"//; s/"$//')
         CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null) || CURRENT_HEAD=""
         if [ -z "$COMMIT_SHA" ] || [ "$COMMIT_SHA" != "$CURRENT_HEAD" ]; then
-            echo "CROSS-MODEL REVIEW REQUIRED: .reviews/handoff.json certification is stale (commit_sha does not match current HEAD — new commits landed since certification). Re-run Codex cross-model review. Set CODEX_GATE_SKIP=1 to bypass with justification." >&2
+            echo "CROSS-MODEL REVIEW REQUIRED: .reviews/handoff.json certification is stale (commit_sha does not match current HEAD — new commits landed since certification). Re-run Codex cross-model review. Human override: relaunch Claude Code with CODEX_GATE_SKIP=1 in its environment — this hook runs before your command, so an inline prefix inside a tool call cannot reach it. Your own terminal is unaffected; this is a Claude Code hook, not a git hook." >&2
             exit 2
         fi
         exit 0
         ;;
     *)
-        echo "CROSS-MODEL REVIEW REQUIRED: .reviews/handoff.json status is '$STATUS' (need REVIEWED or CERTIFIED). Run Codex cross-model review before committing. Set CODEX_GATE_SKIP=1 to bypass with justification." >&2
+        echo "CROSS-MODEL REVIEW REQUIRED: .reviews/handoff.json status is '$STATUS' (need REVIEWED or CERTIFIED). Run Codex cross-model review before committing. Human override: relaunch Claude Code with CODEX_GATE_SKIP=1 in its environment — this hook runs before your command, so an inline prefix inside a tool call cannot reach it. Your own terminal is unaffected; this is a Claude Code hook, not a git hook." >&2
         exit 2
         ;;
 esac

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -63,16 +63,42 @@ COMMAND_FIELD=$(printf '%s' "$TOOL_INPUT" \
 # never look like more than one word to it.
 COMMAND_VALUE=$(printf '%s' "$COMMAND_FIELD" \
     | sed -E 's/^"command"[[:space:]]*:[[:space:]]*"(.*)"$/\1/')
+# The interior class must mirror the escape-aware extraction above:
+# `[^\\]*` cannot cross the backslashes inside a heredoc body, so a quoted
+# span containing one was never collapsed. `([^\\]|\\[^"])*` consumes an
+# escaped non-quote as one unit; neither alternative can match `\"`, so the
+# span still self-terminates at the real closing quote and cannot over-consume.
 MASKED_COMMAND=$(printf '%s' "$COMMAND_VALUE" \
-    | sed -E -e 's/\\"[^\\]*\\"/Q/g' -e "s/'[^']*'/Q/g")
+    | sed -E -e 's/\\"([^\\]|\\[^"])*\\"/Q/g' -e "s/'[^']*'/Q/g")
+
+# #533 P0-3: decode literal \n and \r to real newlines — AFTER masking.
+#
+# The gate has never seen a `git commit` that was not on the first line. In
+# COMMAND_VALUE a JSON newline is still the two characters `\` and `n`, so in
+# `echo hi\ngit commit` the `\bgit` below sits immediately after the word
+# character `n` and the word boundary never fires. Verified against this
+# hook's own parent commit: `git add -A\ngit commit -m "x"` returned 0 with no
+# review artifact present at all. Every multi-line command has walked past
+# this gate since it was written. That is the gate's whole purpose failing
+# open, and it is not a regression from the in-flight lane — it predates it.
+#
+# Order is load-bearing: masking is line-based (sed), so a quoted span that
+# spans lines could no longer be collapsed once the newlines are real.
+MASKED_COMMAND=$(printf '%s' "$MASKED_COMMAND" | sed -E -e 's/\\n/\n/g' -e 's/\\r/\n/g')
 
 # #236(b): literal substring "git commit" misses git's own global-flag forms
 # — `git -C <dir> commit` and `git -c k=v commit` are valid invocations that
 # never contain that exact two-word substring, and previously sailed through
 # unreviewed. Regex allows any number of -C/-c (with their required value),
 # --long-flag, or single-letter-flag tokens between "git" and "commit".
+#
+# #533 P0-4: git accepts a short option's value attached, so `git -C/other
+# commit` is a real invocation the `-C\s+\S+` alternative could not match —
+# it fell through to `-[A-Za-z]`, which then demanded `commit` where `/other`
+# stood. Verified against this hook's own parent: exit 0, no artifact needed.
+# `\s*` in place of `\s+` covers both spellings for -C and -c alike.
 if ! printf '%s' "$MASKED_COMMAND" \
-    | grep -qE '\bgit(\s+(-C\s+\S+|-c\s+\S+|--\S+|-[A-Za-z]))*\s+commit\b'; then
+    | grep -qE '\bgit(\s+(-[Cc]\s*\S+|--\S+|-[A-Za-z]))*\s+commit\b'; then
     exit 0
 fi
 
@@ -108,23 +134,94 @@ STATUS=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$REVIEW_FILE" \
 # file: every git capture needs `|| true` (a non-match exits 1 and kills the
 # script), and the comparison must be a full `if`, never `[ ... ] && VAR=0`
 # (a false test returns 1 and kills the script).
-ON_DEFAULT_BRANCH=1
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-DEFAULT_BRANCH=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
-DEFAULT_BRANCH="${DEFAULT_BRANCH#origin/}"
-case "$CURRENT_BRANCH" in
-    ""|HEAD|main|master) ;;
-    *)
-        if [ -n "$DEFAULT_BRANCH" ]; then
-            if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then ON_DEFAULT_BRANCH=0; fi
-        elif git show-ref --verify --quiet refs/heads/main \
-            || git show-ref --verify --quiet refs/heads/master \
-            || git show-ref --verify --quiet refs/remotes/origin/main \
-            || git show-ref --verify --quiet refs/remotes/origin/master; then
-            ON_DEFAULT_BRANCH=0
+# LANE_OK is a conjunction of independent NECESSARY conditions. Anything
+# unproven refuses the lane. Every earlier draft of this failed because it
+# looked for evidence that the branch is NOT the default; the only sound
+# question is whether it is PROVABLY not.
+LANE_OK=0
+
+# (a) The command must provably operate on this hook's own cwd.
+#
+# The resolver below reads the repository the hook is standing in. If the
+# intercepted command targets a different one, every answer it gives is about
+# the wrong repo — `git -C <repo-on-main> commit` was granted the lane while
+# the hook's cwd sat on a feature branch. Before the lane existed an in-flight
+# status blocked unconditionally, so that mismatch failed strict; the lane
+# converted it to fail lenient.
+#
+# This is a POSITIVE shape test, not a blacklist of escapes, and it gates ONLY
+# the lane. Detection above stays maximally broad; eligibility is maximally
+# narrow. Command substitution needs no ban — `$(...)` runs in a subshell whose
+# cwd cannot affect the parent's commit — which is what keeps heredocs eligible.
+#
+# Known limitation, accepted deliberately: a bare `git commit -F - <<'MSG'`
+# loses the lane. That heredoc body is unquoted, so masking cannot reach it and
+# a prose line is indistinguishable from a command segment here. The three forms
+# that carry a body through a quoted span — `-m "multi\nline"`, `-m "$(cat
+# <<'EOF' ...)"`, and `-F <file>` — all keep it, so no commit is prevented; one
+# spelling of it is. Failing strict is the right direction for a coarse test.
+ELIGIBLE=1
+# Any relocation token anywhere refuses. `-C` matches with no separator
+# requirement: `git -C/other/repo commit` is valid git.
+if printf '%s' "$MASKED_COMMAND" | grep -qE '(^|[^[:alnum:]_.-])(cd|pushd|popd|chdir)([^[:alnum:]_.-]|$)|(^|[[:space:]])-C|--git-dir|--work-tree|GIT_DIR|GIT_WORK_TREE'; then
+    ELIGIBLE=0
+fi
+# Every segment must itself be a git invocation. Counting, never `grep -qv`:
+# a wrapper script or a non-git chain member can relocate in ways no token
+# test sees.
+if [ "$ELIGIBLE" -eq 1 ]; then
+    _seg_total=$(printf '%s' "$MASKED_COMMAND" | tr '\n' '\036' | sed -E 's/(&&|\|\||;|\|)/\036/g' | tr '\036' '\n' | grep -cE '[^[:space:]]' || true)
+    _seg_git=$(printf '%s' "$MASKED_COMMAND" | tr '\n' '\036' | sed -E 's/(&&|\|\||;|\|)/\036/g' | tr '\036' '\n' | grep -cE '^[[:space:]]*git([[:space:]]|$)' || true)
+    if [ "$_seg_total" -ne "$_seg_git" ]; then
+        ELIGIBLE=0
+    fi
+fi
+
+if [ "$ELIGIBLE" -eq 1 ]; then
+    # (b) Must be a real work tree. Kills bare repos.
+    _INSIDE=$(git rev-parse --is-inside-work-tree 2>/dev/null || true)
+    # (c) HEAD must be attached. `symbolic-ref` fails cleanly when detached,
+    #     where `rev-parse --abbrev-ref` prints the literal string "HEAD".
+    CURRENT_BRANCH=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+    if [ "$_INSIDE" = "true" ] && [ -n "$CURRENT_BRANCH" ]; then
+        # (d) Reserved-trunk denylist, case-insensitive. This is the second
+        #     independent witness, and it is load-bearing rather than
+        #     decorative: a STALE origin/HEAD is offline-indistinguishable
+        #     from a fresh one (`git remote set-head -a` needs the network),
+        #     so a repo whose trunk moved to `develop` while origin/HEAD still
+        #     says `master` would otherwise resolve "current != default" and
+        #     take the lane ON its trunk. This check can only ever add
+        #     strictness: a false refusal costs a lane, never soundness.
+        _LOWER=$(printf '%s' "$CURRENT_BRANCH" | tr '[:upper:]' '[:lower:]')
+        case "$_LOWER" in
+            main|master|develop|development|dev|trunk|default|stable|prod|production|release|releases|integration|next)
+                _RESERVED=1 ;;
+            *)  _RESERVED=0 ;;
+        esac
+        if [ "$_RESERVED" -eq 0 ]; then
+            # (e) At least one remote must yield a VERIFIED default, and the
+            #     current branch must differ from every remote's default. A
+            #     dangling symref target is not evidence, so the target ref
+            #     must itself exist. The vestigial refs/heads/main fallback is
+            #     deliberately gone: "a main ref exists somewhere" proved
+            #     nothing about which branch this repo's trunk is.
+            _ANY_VERIFIED=0
+            _CONFLICT=0
+            for _r in $(git remote 2>/dev/null || true); do
+                _d=$(git symbolic-ref --quiet --short "refs/remotes/$_r/HEAD" 2>/dev/null || true)
+                _d="${_d#"$_r"/}"
+                [ -z "$_d" ] && continue
+                if git show-ref --verify --quiet "refs/remotes/$_r/$_d"; then
+                    _ANY_VERIFIED=1
+                    if [ "$CURRENT_BRANCH" = "$_d" ]; then _CONFLICT=1; fi
+                fi
+            done
+            if [ "$_ANY_VERIFIED" -eq 1 ] && [ "$_CONFLICT" -eq 0 ]; then
+                LANE_OK=1
+            fi
         fi
-        ;;
-esac
+    fi
+fi
 
 case "$STATUS" in
     PENDING_REVIEW|PENDING_RECHECK)
@@ -138,10 +235,10 @@ case "$STATUS" in
         # commit_sha is deliberately not read here: on this lane it is either
         # absent by design (never certified) or stale by design (a round is
         # open). Freshness is lane CERTIFIED/REVIEWED's job, and it keeps it.
-        if [ "$ON_DEFAULT_BRANCH" -eq 0 ]; then
+        if [ "$LANE_OK" -eq 1 ]; then
             exit 0
         fi
-        echo "CROSS-MODEL REVIEW REQUIRED: status is '$STATUS' (a review round is open) and this looks like the default branch${DEFAULT_BRANCH:+ [$DEFAULT_BRANCH]}${CURRENT_BRANCH:+, current [$CURRENT_BRANCH]}. In-flight work may be committed on a non-default branch so reviewers get an immutable SHA instead of a live tree; reaching the default branch still needs a certification bound to that exact HEAD. Human override: relaunch Claude Code with CODEX_GATE_SKIP=1 in its environment — this hook runs before your command, so an inline prefix inside a tool call cannot reach it." >&2
+        echo "CROSS-MODEL REVIEW REQUIRED: status is '$STATUS' (a review round is open) but this commit is not provably off the default branch${CURRENT_BRANCH:+ [current: $CURRENT_BRANCH]}. In-flight work may be committed on a non-default branch so reviewers get an immutable SHA instead of a live tree; reaching the default branch still needs a certification bound to that exact HEAD. Human override: relaunch Claude Code with CODEX_GATE_SKIP=1 in its environment — this hook runs before your command, so an inline prefix inside a tool call cannot reach it." >&2
         exit 2
         ;;
     CERTIFIED|REVIEWED)

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -3896,6 +3896,16 @@ _gate_repo() {
     printf '%s' "$d"
 }
 
+_gate_clone() {
+    # $1 = dir, $2 = the branch origin/HEAD should name. Gives the fixture the
+    # shape `git clone` leaves behind, which is the ONLY shape the resolver
+    # accepts as proof. A bare `git init` repo has no default-branch evidence
+    # at all, so it must block — see F4.
+    git -C "$1" remote add origin /nonexistent-not-contacted
+    git -C "$1" update-ref "refs/remotes/origin/$2" "$(git -C "$1" rev-parse HEAD)"
+    git -C "$1" symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/$2"
+}
+
 _gate_run() {
     # $1 = dir, $2 = command json value. Echoes output, RETURNS the hook's
     # exit code. It must return rather than set a global: callers invoke this
@@ -3915,6 +3925,7 @@ _gate_run() {
 test_codex_gate_inflight_recheck_allowed_on_feature_branch() {
     local d out
     d=$(_gate_repo feature/x)
+    _gate_clone "$d" main
     printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
     out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
     rm -rf "$d"
@@ -3932,6 +3943,7 @@ test_codex_gate_inflight_recheck_allowed_on_feature_branch() {
 test_codex_gate_inflight_review_allowed_on_feature_branch() {
     local d out
     d=$(_gate_repo feature/x)
+    _gate_clone "$d" main
     printf '{"status":"PENDING_REVIEW","round":1}' > "$d/.reviews/handoff.json"
     out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
     rm -rf "$d"
@@ -4013,6 +4025,10 @@ test_codex_gate_inflight_silent_on_non_commit_command() {
 test_codex_gate_inflight_blocked_on_default_branch() {
     local d out
     d=$(_gate_repo "")
+    # Clone-shaped and pointed at the branch we are standing on, so this blocks
+    # because it IS the default branch — not merely because a bare `git init`
+    # fixture offers no evidence either way.
+    _gate_clone "$d" "$(git -C "$d" symbolic-ref --quiet --short HEAD)"
     printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
     out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
     rm -rf "$d"
@@ -4051,6 +4067,159 @@ test_codex_gate_feature_branch_does_not_relax_stale_check() {
     else
         fail "#533: stale cert on a feature branch must exit 2 stale, got exit=$_GATE_EXIT out: $out"
     fi
+}
+
+# ---- #533 round 2: the two silent bypasses Codex reproduced, plus a third ----
+#
+# Round 1 shipped a lane whose branch check consulted whatever refs happened to
+# be lying around, and whose "is this repo the one being committed to" question
+# was never asked at all. Both failed LENIENT, which is the only direction that
+# matters: the lane turned a hard block into a silent allow.
+#
+# The rule the F-tests pin: proof, not absence of contradiction. The resolver
+# admits exactly one shape — a remote whose `refs/remotes/<r>/HEAD` symref
+# resolves to a ref that actually exists — and every other topology blocks.
+# A local `main` ref, a stale symref, a dangling symref, and a bare `git init`
+# are all "we do not know", and "we do not know" is not a lane.
+#
+# The rule the G-tests pin: the hook can only vouch for the repository it is
+# standing in, so a command that relocates git elsewhere is ineligible by
+# shape. This is deliberately coarse — `cd`, `-C`, `--git-dir`, `GIT_DIR` and
+# any non-git segment refuse the lane rather than trying to model the shell.
+# Refusing the lane is not a block; it just falls through to the old rules.
+
+_gate_lane_case() {
+    # $1 = label, $2 = expected exit, $3 = command json value, $4.. = setup
+    # commands run against the fixture dir (available to them as $d).
+    local label="$1" want="$2" cmd="$3" out rc
+    shift 3
+    d=$(_gate_repo "")
+    mkdir -p "$d/.reviews"
+    printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
+    for _s in "$@"; do eval "$_s"; done
+    out=$(_gate_run "$d" "$cmd") && rc=0 || rc=$?
+    rm -rf "$d"
+    if [ "$rc" -eq "$want" ]; then
+        pass "#533: $label"
+    else
+        fail "#533: $label — want exit $want, got $rc: $out"
+    fi
+}
+
+_GC='git commit -m \"wip\"'
+
+# F — the resolver. Every row that is not a verified clone must block.
+test_codex_gate_resolver_topologies() {
+    _gate_lane_case "clone-shaped feature branch is the ONLY lane" 0 "$_GC" \
+        'git -C "$d" checkout -q -B feature/x' '_gate_clone "$d" main'
+
+    # Codex reproduced this one: the default moved to develop years ago, the
+    # symref was never repointed, and "origin/HEAD names something else" read
+    # as proof of a feature branch.
+    _gate_lane_case "stale origin/HEAD does not prove non-default" 2 "$_GC" \
+        'git -C "$d" checkout -q -B develop' '_gate_clone "$d" master'
+
+    # Codex reproduced this one too: a leftover master ref from a rename is
+    # not evidence about which branch the remote considers default.
+    _gate_lane_case "vestigial local master is not evidence" 2 "$_GC" \
+        'git -C "$d" checkout -q -B develop' \
+        'git -C "$d" update-ref refs/heads/master "$(git -C "$d" rev-parse HEAD)"'
+
+    _gate_lane_case "dangling origin/HEAD blocks" 2 "$_GC" \
+        'git -C "$d" checkout -q -B feature/x' \
+        'git -C "$d" remote add origin /nonexistent-not-contacted' \
+        'git -C "$d" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/gone'
+
+    # The common consumer shape. `git init` with no remote knows nothing about
+    # a default branch, so it gets no lane.
+    _gate_lane_case "git init with no remote blocks" 2 "$_GC" \
+        'git -C "$d" checkout -q -B feature/x'
+
+    # A trunk name must not be admitted just because the casing differs.
+    _gate_lane_case "reserved trunk name blocks case-insensitively" 2 "$_GC" \
+        'git -C "$d" checkout -q -B Develop' '_gate_clone "$d" main'
+
+    # Fork workflow: origin says feature/x is not default, upstream says it is.
+    # Any remote calling it default is enough to refuse the lane.
+    _gate_lane_case "a second remote calling it default blocks" 2 "$_GC" \
+        'git -C "$d" checkout -q -B feature/x' '_gate_clone "$d" main' \
+        'git -C "$d" remote add upstream /nonexistent-not-contacted-2' \
+        'git -C "$d" update-ref refs/remotes/upstream/feature/x "$(git -C "$d" rev-parse HEAD)"' \
+        'git -C "$d" symbolic-ref refs/remotes/upstream/HEAD refs/remotes/upstream/feature/x'
+}
+
+# G — targeting and detection. The hook vouches for its own cwd or nothing.
+test_codex_gate_lane_targeting_and_detection() {
+    local clone='git -C "$d" checkout -q -B feature/x' mk='_gate_clone "$d" main'
+
+    _gate_lane_case "plain commit takes the lane" 0 "$_GC" "$clone" "$mk"
+    _gate_lane_case "git add && commit takes the lane" 0 \
+        'git add -A \&\& git commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "-c overrides take the lane" 0 \
+        'git -c user.name=\"A B\" commit -m \"wip\"' "$clone" "$mk"
+
+    # Codex P0-1: the hook read its own branch and vouched for a DIFFERENT
+    # repository, which was sitting on main. Every relocation form must refuse.
+    _gate_lane_case "git -C elsewhere refuses the lane" 2 \
+        'git -C /other commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "cd elsewhere refuses the lane" 2 \
+        'cd /other \&\& git commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "subshell cd refuses the lane" 2 \
+        '(cd /other; git commit -m \"wip\")' "$clone" "$mk"
+    _gate_lane_case "--git-dir refuses the lane" 2 \
+        'git --git-dir=/other/.git commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "GIT_DIR env prefix refuses the lane" 2 \
+        'GIT_DIR=/other/.git git commit -m \"wip\"' "$clone" "$mk"
+    # The work-tree pair relocates the tree rather than the repo, and reaches a
+    # different checkout just as effectively. The relocation regex covered both
+    # from the start; these pin it so a future trim cannot drop them silently.
+    _gate_lane_case "--work-tree refuses the lane" 2 \
+        'git --work-tree=/other commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "GIT_WORK_TREE env prefix refuses the lane" 2 \
+        'GIT_WORK_TREE=/other git commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "a non-git segment refuses the lane" 2 \
+        'npm run prepare \&\& git commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "a later relocation refuses the whole command" 2 \
+        'git commit -m \"a\"\ncd /other\ngit commit -m \"b\"' "$clone" "$mk"
+
+    # P0-3, found while verifying the above. COMMAND_VALUE holds a newline as
+    # the two characters \ and n, so `\bgit` sat right after the word character
+    # n and the boundary never fired. Confirmed against 435708a: a multi-line
+    # command reached exit 0 with NO artifact present at all. Every multi-line
+    # commit in this hook's history walked straight past the gate.
+    _gate_lane_case "multi-line add + commit takes the lane" 0 \
+        'git add -A\ngit commit -m \"wip\"' "$clone" "$mk"
+    _gate_lane_case "multi-line commit is DETECTED at all" 2 \
+        'echo hi\ngit commit -m \"wip\"' "$clone" "$mk" 'rm -rf "$d/.reviews"'
+
+    # P0-4, same family. git takes a short option's value attached, so
+    # `git -C/other commit` is real and `-C\s+\S+` could not match it; it fell
+    # to `-[A-Za-z]`, which then wanted `commit` where `/other` stood. Also
+    # confirmed exit 0 against 435708a.
+    _gate_lane_case "attached -C value is DETECTED at all" 2 \
+        'git -C/other commit -m \"wip\"' "$clone" "$mk"
+
+    # The lane's usable surface, pinned. A conventional-commit body is prose,
+    # and prose contains the word cd and the characters ; and && — so the three
+    # forms that carry a body through a QUOTED span must survive masking, or
+    # #533 delivers a lane no real commit in this repo can take.
+    _gate_lane_case "quoted multi-line -m keeps the lane" 0 \
+        'git commit -q -m \"fix(x): a thing\n\nprose mentioning cd here\"' "$clone" "$mk"
+    _gate_lane_case "-F with a message file keeps the lane" 0 \
+        'git commit -q -F /tmp/msg.txt' "$clone" "$mk"
+
+    # The one form that does NOT: a bare `-F -` heredoc. Its body is unquoted,
+    # so masking cannot reach it and the shape test cannot tell a prose line
+    # from a command segment. Refusing is the correct direction to fail — the
+    # commit is not blocked, it just needs one of the forms above. Pinned so
+    # the limitation is a decision on record rather than a surprise later.
+    _gate_lane_case "bare -F - heredoc refuses the lane (known, fail-strict)" 2 \
+        'git commit -q -F - <<'"'"'MSG'"'"'\nfix(x): a thing\n\nprose mentioning cd here\nMSG' \
+        "$clone" "$mk"
+
+    _gate_lane_case "heredoc message with shell metacharacters keeps the lane" 0 \
+        'git commit -q -m \"$(cat <<'"'"'EOF'"'"'\nfix: a thing; and another \&\& more\nmentions cd /tmp in the body\nEOF\n)\"' \
+        "$clone" "$mk"
 }
 
 # Changed for #533: this tmpdir was not a git repo, so after the in-flight
@@ -4199,6 +4368,8 @@ test_codex_gate_inflight_silent_on_non_commit_command
 test_codex_gate_inflight_blocked_on_default_branch
 test_codex_gate_feature_branch_still_needs_an_artifact
 test_codex_gate_feature_branch_does_not_relax_stale_check
+test_codex_gate_resolver_topologies
+test_codex_gate_lane_targeting_and_detection
 test_codex_gate_blocks_commit_without_review
 test_codex_gate_allows_commit_with_certified_review
 test_codex_gate_allows_commit_with_reviewed_status

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -3864,10 +3864,203 @@ test_codex_gate_silent_on_non_commit_commands() {
     fi
 }
 
+# ---- #533: the branch-scoped in-flight lane ----
+#
+# The gate blocked every commit unless status was REVIEWED or CERTIFIED, but
+# the shipped protocol prescribes PENDING_REVIEW / PENDING_RECHECK for the
+# whole duration of a review round. So work could not be saved exactly while
+# it was being reviewed, which forced reviewers onto a mutable working tree —
+# and during #520 round 18 a reviewer read a tree a mutation harness was
+# concurrently mutating, and filed a fully-diagnosed P1 against a defect that
+# existed only in the mutation. An entire round spent on an artifact.
+#
+# The lane: an in-flight status may commit, but ONLY onto a branch the hook can
+# positively prove is not the default branch. The gate's purpose is stopping
+# unreviewed work from reaching the default branch, never stopping work from
+# being saved. Everything else blocks exactly as before.
+#
+# Fixture convention: `git init -q` then `git checkout -q -B <name>` — never
+# `git init -b`, which needs git >= 2.28 and this hook ships to consumers.
+# The origin/HEAD ref is built fully offline; it is a local ref that `git
+# clone` writes, so no network is involved in reading or faking it.
+_gate_repo() {
+    # $1 = branch name. Echoes the tmpdir. Caller rm -rf's it.
+    local d
+    d=$(mktemp -d)
+    git -C "$d" init -q
+    git -C "$d" config user.email t@t.t
+    git -C "$d" config user.name t
+    git -C "$d" commit -q --allow-empty -m base
+    [ -n "${1:-}" ] && git -C "$d" checkout -q -B "$1"
+    mkdir -p "$d/.reviews"
+    printf '%s' "$d"
+}
+
+_gate_run() {
+    # $1 = dir, $2 = command json value. Echoes output, RETURNS the hook's
+    # exit code. It must return rather than set a global: callers invoke this
+    # in a command substitution, which is a subshell, so any variable it
+    # assigned would be discarded — the first draft did exactly that and every
+    # assertion read an empty exit code, which made the pinning tests fail for
+    # a reason that had nothing to do with the hook.
+    local out rc
+    out=$(printf '{"tool_input":{"command":"%s"}}' "$2" \
+        | (cd "$1" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && rc=0 || rc=$?
+    printf '%s' "$out"
+    return "$rc"
+}
+
+# T1 — the defect itself. A round is open; work must be savable.
+# The empty-output half also kills "branch resolution leaks git stderr".
+test_codex_gate_inflight_recheck_allowed_on_feature_branch() {
+    local d out
+    d=$(_gate_repo feature/x)
+    printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
+    out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 0 ] && [ -z "$out" ]; then
+        pass "#533: PENDING_RECHECK commits on a feature branch (exit 0, silent)"
+    else
+        fail "#533: PENDING_RECHECK on feature branch should exit 0 silent, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# T2 — round 1 is the worse case, not a lesser one. The wizard's canonical
+# handoff is PENDING_REVIEW/round 1, and that is the status that holds while
+# the FIRST reviewer reads — exactly the configuration that produced the
+# phantom P1. Admitting only PENDING_RECHECK would leave it on a live tree.
+test_codex_gate_inflight_review_allowed_on_feature_branch() {
+    local d out
+    d=$(_gate_repo feature/x)
+    printf '{"status":"PENDING_REVIEW","round":1}' > "$d/.reviews/handoff.json"
+    out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 0 ] && [ -z "$out" ]; then
+        pass "#533: PENDING_REVIEW commits on a feature branch (exit 0, silent)"
+    else
+        fail "#533: PENDING_REVIEW on feature branch should exit 0 silent, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# T3 — forces the origin/HEAD lookup to exist. A hardcoded main|master list
+# would hand a develop-trunk repo the lenient lane on its own trunk.
+test_codex_gate_inflight_blocked_on_resolved_default_develop() {
+    local d out
+    d=$(_gate_repo develop)
+    git -C "$d" update-ref refs/remotes/origin/develop "$(git -C "$d" rev-parse HEAD)"
+    git -C "$d" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+    printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
+    out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 2 ]; then
+        pass "#533: blocked on a resolved default branch named develop"
+    else
+        fail "#533: develop-as-resolved-default should exit 2, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# T4 — `git rev-parse --abbrev-ref HEAD` returns the literal string HEAD when
+# detached, which a naive check would classify as a feature branch.
+test_codex_gate_inflight_blocked_on_detached_head() {
+    local d out
+    d=$(_gate_repo feature/x)
+    git -C "$d" checkout -q --detach
+    printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
+    out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 2 ]; then
+        pass "#533: blocked on detached HEAD (cannot prove it is off the default branch)"
+    else
+        fail "#533: detached HEAD should exit 2, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# T5 — the advertised-but-unreachable escape hatch, in executable form. Every
+# message told callers to set CODEX_GATE_SKIP=1, but the hook reads it from
+# its own process environment; a PreToolUse hook runs BEFORE the command, so
+# an inline prefix inside a tool call cannot produce it. Verified live: two
+# identical blocks. The mechanism is correct and stays (it is the human-only
+# override); the message must stop advertising a route callers cannot take.
+test_codex_gate_message_names_reachable_override_route() {
+    local d out
+    d=$(mktemp -d)
+    out=$(_gate_run "$d" 'git commit -m \"x\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if echo "$out" | grep -qiE 'relaunch|environment of the'; then
+        pass "#533: block message names the reachable override route"
+    else
+        fail "#533: block message must not advertise an inline CODEX_GATE_SKIP prefix, got: $out"
+    fi
+}
+
+# T-N1 — negative fixture (EXISTENCE RULE): the new branch code must not run,
+# and must not print, on non-commit calls.
+test_codex_gate_inflight_silent_on_non_commit_command() {
+    local d out
+    d=$(_gate_repo feature/x)
+    printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
+    out=$(_gate_run "$d" 'git status') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 0 ] && [ -z "$out" ]; then
+        pass "#533: silent on non-commit commands with an in-flight artifact"
+    else
+        fail "#533: git status should exit 0 silent, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# T6 — the boundary this whole lane is scoped by. If this ever goes red the
+# quarantine has broken and in-flight work can reach the default branch.
+test_codex_gate_inflight_blocked_on_default_branch() {
+    local d out
+    d=$(_gate_repo "")
+    printf '{"status":"PENDING_RECHECK","round":2}' > "$d/.reviews/handoff.json"
+    out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 2 ]; then
+        pass "#533: in-flight status still BLOCKED on the default branch"
+    else
+        fail "#533: in-flight on default branch must exit 2, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# T7 — branch-awareness must NOT reach the artifact-absent path, or the gate
+# becomes a no-op on every feature branch.
+test_codex_gate_feature_branch_still_needs_an_artifact() {
+    local d out
+    d=$(_gate_repo feature/x)
+    rm -rf "$d/.reviews"
+    out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 2 ] && echo "$out" | grep -qi "cross-model review"; then
+        pass "#533: a feature branch with no artifact is still blocked"
+    else
+        fail "#533: no artifact on a feature branch must exit 2, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# T8 — the lane must not relax #437's freshness check.
+test_codex_gate_feature_branch_does_not_relax_stale_check() {
+    local d out
+    d=$(_gate_repo feature/x)
+    printf '{"status":"CERTIFIED","commit_sha":"0000000000000000000000000000000000000000"}' \
+        > "$d/.reviews/handoff.json"
+    out=$(_gate_run "$d" 'git commit -m \"wip\"') && _GATE_EXIT=0 || _GATE_EXIT=$?
+    rm -rf "$d"
+    if [ "$_GATE_EXIT" -eq 2 ] && echo "$out" | grep -qi "stale"; then
+        pass "#533: stale certification still blocked on a feature branch"
+    else
+        fail "#533: stale cert on a feature branch must exit 2 stale, got exit=$_GATE_EXIT out: $out"
+    fi
+}
+
+# Changed for #533: this tmpdir was not a git repo, so after the in-flight
+# lane exists it would only have exercised the not-a-repo path and could no
+# longer fail in the direction that matters. It now runs ON the lenient
+# branch, proving an unrecognised status does not open the lane. The status
+# match is an exact allowlist, never "not CERTIFIED" — a typo must not pass.
 test_codex_gate_blocks_on_invalid_status() {
     local tmpdir
-    tmpdir=$(mktemp -d)
-    mkdir -p "$tmpdir/.reviews"
+    tmpdir=$(_gate_repo feature/x)
     printf '{"status":"PENDING"}' > "$tmpdir/.reviews/handoff.json"
     local out exit_code
     out=$(printf '%s' '{"tool_input":{"command":"git commit -m \"fix: thing\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
@@ -3997,6 +4190,15 @@ test_codex_gate_blocks_commit_with_quoted_value_containing_space() {
     fi
 }
 
+test_codex_gate_inflight_recheck_allowed_on_feature_branch
+test_codex_gate_inflight_review_allowed_on_feature_branch
+test_codex_gate_inflight_blocked_on_resolved_default_develop
+test_codex_gate_inflight_blocked_on_detached_head
+test_codex_gate_message_names_reachable_override_route
+test_codex_gate_inflight_silent_on_non_commit_command
+test_codex_gate_inflight_blocked_on_default_branch
+test_codex_gate_feature_branch_still_needs_an_artifact
+test_codex_gate_feature_branch_does_not_relax_stale_check
 test_codex_gate_blocks_commit_without_review
 test_codex_gate_allows_commit_with_certified_review
 test_codex_gate_allows_commit_with_reviewed_status


### PR DESCRIPTION
Closes #533.

The review gate blocked every save while `status` was `PENDING_REVIEW` or `PENDING_RECHECK` — which is the status the shipped protocol prescribes for the entire duration of a review round. Work could not be saved exactly while it was being reviewed, so reviewers read a mutable working tree. During #520 round 18 a reviewer read a tree a mutation harness was concurrently mutating and filed a fully-diagnosed P1 against a defect that existed only in the mutation. A whole round spent on an artifact.

**The lane:** an in-flight status may save, but only onto a branch the hook can *positively prove* is not the default branch. Everything else blocks exactly as before — no artifact, unrecognised status, and #437 staleness all still block, on every branch.

## What round 1 got wrong

Codex reviewed the first implementation and returned NO with two P0s, both of which I reproduced. Both failed **lenient**, which is the only direction that matters: the lane turned a hard block into a silent allow.

**P0-1 — targeting.** The branch check consulted the hook's own cwd, never the repository actually being written to. Relocation is now refused by *shape* rather than modelled: any relocation token, or any chain segment that is not a bare `git` invocation, makes a command ineligible for the lane. Ineligible is not a block — it falls through to the pre-existing rules, which block an in-flight status.

**P0-2 — the resolver.** A leftover local ref from a branch rename, and a symref that was never repointed after a default-branch change, were both being read as proof. Codex was right that the one named hole was not the only one, so the positive-evidence fallback is **deleted rather than patched**. The lane now requires a conjunction of positive proofs: inside a work tree, an attached HEAD, a branch outside the reserved-trunk denylist, and at least one remote whose HEAD symref resolves to a ref that actually exists and names something else. Anything unresolvable is "we do not know", and "we do not know" is not a lane.

## Two holes that predate this branch

Found while verifying the above. Neither is a regression of the lane; both are reproduced against `435708a` on `main`, and in both cases the gate returned **exit 0 with no review artifact present at all**.

**P0-3 — detection.** A newline reaches the hook as two characters, so the word boundary in the detection pattern never fired after one. This gate has never seen a `git commit` that was not on the first line of the command. Every multi-line invocation has walked past it since it was written.

**P0-4 — detection.** A short option accepts its value attached, so one spelling of the repo-relocation flag was a real, valid invocation the old pattern could not match at all.

## Evidence

The verification matrix was executed against three hooks:

| hook | result |
|---|---|
| this HEAD | 20/20 green |
| `d26eb28` (the round-1 hook Codex reviewed) | **15 rows RED** — every one a silent exit 0 |
| `435708a` (`main`) | **2 rows RED** — both detection holes above |

23 permanent assertions in `tests/test-hooks.sh`, all of which execute the hook rather than grepping its source. 243 hook tests pass; all 65 non-E2E CI suites pass locally on macOS.

**Known limitation, on record:** a bare `git commit -F - <<'MSG'` loses the lane, because that heredoc body is unquoted and a prose line is indistinguishable from a command segment to a coarse shape test. The three forms that carry a body through a quoted span all keep it, so no commit is prevented — one spelling of it is. Pinned by a test so it stays a decision rather than a surprise.

**Dogfooded:** the round-2 commit on this branch was made *at* `PENDING_RECHECK` — the exact state that blocked this work twice during #531.

## Reviewer note

macOS is the only platform verified locally. The remaining flagged risk is BSD-vs-GNU divergence in `\b`, `\s`, and `sed`'s newline handling, all of which this change depends on. **Linux CI green is part of the verification here, not a formality.**
