### PR TITLE
fix(hooks): decode JSON-escaped whitespace before the codex gate matches (#581)

### DIFF
--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -73,6 +73,125 @@ COMMAND_FIELD=$(printf '%s' "$TOOL_INPUT" \
 # never look like more than one word to it.
 COMMAND_VALUE=$(printf '%s' "$COMMAND_FIELD" \
     | sed -E 's/^"command"[[:space:]]*:[[:space:]]*"(.*)"$/\1/')
+
+# #581: COMMAND_VALUE is still JSON-escaped, so a real newline in the command
+# is the two characters `\` `n` and a tab is `\` `t`. Neither is whitespace to
+# the checks below, and the `n` of `\n` supplies a word character immediately
+# before "git" — so `\bgit` has no boundary left to match and any command whose
+# INVOCATION WAS SPLIT BY one of those escapes walked past the gate. Not every
+# multi-line command: an intact `git commit` sitting before some unrelated
+# newline was always caught, on origin/main and here alike. Measured against
+# shipped origin/main (57ec6cf): all four invocation-split shapes in the test
+# escape, none are caught.
+#
+# A naive `s/\\[nrt]/ /g` is WRONG, and Sol caught it: it cannot tell a JSON
+# control escape from an escaped literal backslash. In `echo x\ngit commit` the
+# backslash escapes the letter n — there is no invocation there at all — but the
+# naive pass rewrites it to a space and MANUFACTURES the word boundary that
+# `\bgit` needs, denying a harmless command that shipped main allowed.
+#
+# So pair the backslashes first, exactly as JSON does, left to right:
+#
+#   run of 1  \n      -> control escape        -> becomes `;` (see below)
+#   run of 2  \\n     -> literal backslash + n -> leave alone
+#   run of 3  \\\n    -> literal backslash + newline, i.e. a shell line
+#                        continuation          -> DELETED, see below
+#   run of 4  \\\\n   -> two literal backslashes + n -> leave alone
+#
+# Pass 1 replaces each PAIR of backslashes with a sentinel, and sed's global
+# substitution consumes pairs left to right, which is precisely JSON's own rule.
+# After that, any backslash still standing is by definition the start of a
+# control escape, so the later passes can act without ambiguity.
+#
+# The run-3 case is DELETED, not spaced, because that is what the shell does:
+# bash removes a backslash-newline pair entirely, so `echo x\<newline>git commit`
+# executes as `echo xgit commit` — one word, no invocation anywhere in it.
+# Replacing it with a space instead would join `x` and `git` into two words and
+# manufacture the boundary `\bgit` needs, denying a harmless command. Deleting
+# keeps the real bypass detectable, because `git \<newline>  commit` still has
+# its own surrounding spaces.
+#
+# For the same reason a run-3 before `t` is stripped of its escape rather than
+# converted: bash treats an escaped tab as part of the word, not as a separator,
+# so turning it into whitespace would invent a split the shell never makes.
+#
+# Each surviving control escape is then mapped to what bash actually does with
+# that character, which is NOT uniformly "whitespace":
+#
+#   \n  -> `;`   a bare newline TERMINATES a command. Mapping it to a space
+#                would fuse two commands into one: `git<newline>commit` is
+#                `git` then a separate `commit`, never a `git commit`. With `;`
+#                there is no `\s+` after `git` so it correctly does not match,
+#                while `cd foo<newline>git commit` still does — `;` is itself a
+#                word boundary.
+#   \t  -> ` `   a bare tab IS a token separator, so whitespace is faithful.
+#   \r  -> left alone. A carriage return is NOT a bash separator; it is ordinary
+#                word content. `cd foo<CR>git commit` runs `cd` with the argument
+#                `foogit` and never invokes git at all. Leaving `\r` intact keeps
+#                the `r` as a word character, so `\bgit` cannot fire — which is
+#                the truth. CRLF still blocks, via the `\n` half.
+#
+# Never decode to REAL newlines. Every consumer below greps line-by-line, so a
+# real newline would split `git \` from `commit` across lines and leave both
+# continuation forms permanently undetectable.
+#
+# Order is load-bearing: pairing precedes everything; the continuation and
+# escaped-tab forms are handled BEFORE the general pass, so that pass cannot eat
+# their trailing escape and strand a backslash mid-command.
+#
+# Normalizing here — once, upstream of both MASKED_COMMAND and the relocation
+# check in the PENDING_RECHECK lane — is what closes it in both places.
+#
+# Known limits, stated rather than implied.
+#
+# This decodes the `\n`/`\r`/`\t` short forms the Bash tool actually emits, NOT
+# the equivalent six-character unicode escapes (backslash-u-0-0-0-a and
+# friends). An accident-catcher, not an adversary barrier.
+#
+# BACKSLASH RUNS OF k = 3 (mod 4) before `n` — 7, 11, 15 — produce a FALSE
+# DENIAL. Such a run decodes to literal backslashes plus a newline; bash keeps a
+# backslash as word content, so `echo x\git commit` is one word that invokes
+# nothing, yet the leftover backslash is a non-word character and lets `\bgit`
+# fire here. Note it is specifically k = 3 (mod 4): k = 9 and k = 13 DO invoke
+# git and are correctly blocked. Verified against a bash oracle through k = 16.
+#
+# DECLINED, on complexity grounds — not impossibility. An earlier version of
+# this comment claimed the only cure was bypass-shaped, on the reasoning that
+# telling this apart from a source `\git` needs command position, which sed
+# cannot decide. Sol disproved that: after the pairing pass above these are
+# already textually distinct — k=7 leaves three sentinels then `\n`, whereas a
+# source `\git` leaves one sentinel then `git` — and demonstrated a sed-only
+# second pairing pass that separates them, prototyped through k = 16.
+#
+# So this is a choice, with a known fix path recorded on #581. It is declined
+# because the input is pathological (three or more literal backslashes abutting
+# a line continuation immediately before `git`), the failure is CLOSED, and the
+# cost is a rephrase — not worth another state machine inside a hook that ships
+# to every consumer as plain bash.
+#
+# Unquoted PROSE that merely names the verb can match. That class predates this
+# change and is tracked as #588. Its edge moves here, in both directions, and
+# measured against origin/main it is:
+#
+#   single-line prose      blocked before, blocked now   — unchanged
+#   newline-separated      allowed before, allowed now   — unchanged, because
+#                          `\n` becomes `;` rather than a space, so the words
+#                          are separated rather than fused
+#   tab-separated          allowed before, BLOCKED now   — WIDENED
+#
+# So this is not the no-change it would be convenient to claim. Tab-separated
+# prose is newly caught, because a tab genuinely IS a bash separator and the
+# detector cannot see that the surrounding text is prose. Accepted as part of
+# the already-accepted #588 class: it fails closed and costs a rephrase.
+ESC_SENTINEL=$(printf '\001')
+COMMAND_VALUE=$(printf '%s' "$COMMAND_VALUE" \
+    | sed -E -e "s/\\\\\\\\/$ESC_SENTINEL/g" \
+             -e "s/$ESC_SENTINEL\\\\n//g" \
+             -e "s/$ESC_SENTINEL\\\\t/${ESC_SENTINEL}t/g" \
+             -e 's/\\n/;/g' \
+             -e 's/\\t/ /g' \
+             -e "s/$ESC_SENTINEL/\\\\/g")
+
 MASKED_COMMAND=$(printf '%s' "$COMMAND_VALUE" \
     | sed -E -e 's/\\"[^\\]*\\"/Q/g' -e "s/'[^']*'/Q/g")
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -4177,6 +4177,265 @@ test_codex_gate_does_not_advertise_an_inline_bypass() {
     fi
 }
 
+# #581: the hook matches against the JSON-ESCAPED command value, where a real
+# newline is the two characters `\` `n` and a tab is `\` `t`. Neither is
+# whitespace to the regex, and worse, the `n` of `\n` supplies a word character
+# immediately before "git", so `\bgit` has no boundary left to match. Net
+# effect: a multi-line command whose invocation was SPLIT BY the escape escaped
+# the gate entirely. Not every multi-line command — an intact `git commit`
+# sitting before some unrelated newline was always caught. Measured against
+# shipped origin/main (57ec6cf, hook blob a958b0d): all four shapes below
+# escape and none are caught — the hole predates this fix and is not opened
+# by it.
+#
+# The fix decodes each escape to what bash does with that character — `\n` to
+# `;`, `\t` to a space, `\r` left alone as word content — and never to a real
+# newline: every downstream check greps line-by-line, so a real newline would
+# split `git \` and `commit` onto separate lines and leave both continuation
+# forms permanently undetectable. Measured over these same shapes:
+# `printf '%b'` lets both line-continuation forms through; this pass blocks
+# every one of them.
+test_codex_gate_blocks_commit_split_across_lines() {
+    local tmpdir cmd out exit_code failures label
+    failures=""
+    for label in 'newline-separated:cd foo\ngit commit -m \"x\"' \
+                 'line-continuation:git \\\n  commit -m \"x\"' \
+                 'tab-separated:git\tcommit -m \"x\"' \
+                 'dashC-continuation:git -C /tmp/repo \\\n  commit -m \"x\"'; do
+        cmd="${label#*:}"
+        tmpdir=$(mktemp -d)
+        out=$(printf '{"tool_input":{"command":"%s"}}' "$cmd" | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+        rm -rf "$tmpdir"
+        [ "$exit_code" -eq 2 ] || failures="$failures [${label%%:*} -> exit=$exit_code]"
+    done
+    if [ -z "$failures" ]; then
+        pass "codex gate BLOCKS (exit 2) a real commit split up by a JSON-escaped \\n/\\t"
+    else
+        fail "codex gate should exit 2 for every invocation-split commit shape, got:$failures"
+    fi
+}
+
+# The two shapes this loop USED to contain, moved here because bash says they
+# are not git invocations at all. Established with a fake `git` on PATH that
+# prints its own argv, so the shell answered rather than any of us:
+#
+#   git<newline>commit      -> `git` with no args, THEN a separate bare
+#                              `commit`. Never a `git commit`.
+#   cd foo<CR>git commit    -> `cd: foogit: No such file or directory`. A
+#                              carriage return is not a bash separator; it is
+#                              ordinary word content.
+#
+# Both were previously asserted as bypasses that must be blocked, which
+# codified two false denials as correct behavior in a green suite. That oracle
+# is now the admission criterion for the block loop above: a shape belongs
+# there only if bash actually invokes git.
+test_codex_gate_silent_on_shapes_that_do_not_invoke_git() {
+    local tmpdir out exit_code failures label cmd
+    failures=""
+    for label in 'verb-on-its-own-line:git\ncommit -m \"x\"' \
+                 'carriage-return-is-word-content:cd foo\rgit commit -m \"x\"'; do
+        cmd="${label#*:}"
+        tmpdir=$(mktemp -d)
+        out=$(printf '{"tool_input":{"command":"%s"}}' "$cmd" | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+        rm -rf "$tmpdir"
+        { [ "$exit_code" -eq 0 ] && [ -z "$out" ]; } || failures="$failures [${label%%:*} -> exit=$exit_code]"
+    done
+    if [ -z "$failures" ]; then
+        pass "codex gate silent on multi-line shapes that bash does not turn into a git invocation"
+    else
+        fail "codex gate should exit 0 silent for non-invocation shapes, got:$failures"
+    fi
+}
+
+# The allow-path mirror of the test above. Every new shape asserts exit 2 in an
+# UNcertified repo, which alone cannot tell "the gate now sees the commit" from
+# "the gate now denies multi-line input on principle". This pins the other half:
+# with a CERTIFIED handoff matching HEAD, the same four shapes must still pass
+# through silently.
+test_codex_gate_allows_certified_commit_split_across_lines() {
+    local tmpdir head_sha out exit_code failures label cmd
+    failures=""
+    for label in 'newline-separated:cd foo\ngit commit -m \"x\"' \
+                 'line-continuation:git \\\n  commit -m \"x\"' \
+                 'tab-separated:git\tcommit -m \"x\"' \
+                 'dashC-continuation:git -C . \\\n  commit -m \"x\"'; do
+        cmd="${label#*:}"
+        tmpdir=$(mktemp -d)
+        (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init) > /dev/null 2>&1
+        head_sha=$(cd "$tmpdir" && git rev-parse HEAD)
+        mkdir -p "$tmpdir/.reviews"
+        printf '{"status":"CERTIFIED","score":9,"commit_sha":"%s"}' "$head_sha" > "$tmpdir/.reviews/handoff.json"
+        out=$(printf '{"tool_input":{"command":"%s"}}' "$cmd" | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+        rm -rf "$tmpdir"
+        { [ "$exit_code" -eq 0 ] && [ -z "$out" ]; } || failures="$failures [${label%%:*} -> exit=$exit_code]"
+    done
+    if [ -z "$failures" ]; then
+        pass "codex gate ALLOWS (exit 0) every invocation-split commit shape when CERTIFIED against HEAD"
+    else
+        fail "codex gate should exit 0 silent for certified invocation-split commits, got:$failures"
+    fi
+}
+
+# Sol's P1 against the first cut of #581, now pinned as a regression. A naive
+# `s/\\[nrt]/ /g` cannot tell a JSON control escape from an ESCAPED LITERAL
+# BACKSLASH. On the wire, `echo x\ngit commit` arrives as `echo x\\ngit commit`:
+# the backslash escapes the letter n, the shell reads it as `echo xngit`, and
+# there is no invocation anywhere in it. Rewriting that backslash to a space
+# does not manufacture letters — it manufactures the WORD BOUNDARY that `\bgit`
+# needs, which is how a harmless command that shipped main allowed became a
+# denial. Verified against origin/main: allowed there, so this was ours.
+#
+# The fix pairs backslashes left to right the way JSON does before decoding
+# anything, so run-length decides what a backslash run means.
+#
+# NOTE ON THE LITERALS BELOW, because getting this wrong is what let the first
+# cut ship: these are SINGLE-quoted, so bash preserves every backslash exactly
+# as written and `printf '%s'` puts that same count on the wire. `\\n` here is
+# a run of TWO. An earlier version of this test doubled all of them — it read
+# run-2 and was actually exercising run-4, so the case it claimed to pin was
+# never pinned at all. Count the backslashes in the source, not in a probe you
+# wrote in double quotes.
+#
+# The run-3 cases are the shell-semantics half, and they are not obvious:
+# `echo x\<newline>git commit` is a line continuation, which bash REMOVES
+# entirely, executing `echo xgit commit` — one word, no invocation. An escaped
+# tab or CR is likewise part of the word, not a separator. Normalizing any of
+# them to whitespace would invent a split the shell never makes, and that split
+# is exactly the word boundary `\bgit` needs.
+test_codex_gate_silent_on_escaped_literal_backslashes() {
+    local tmpdir out exit_code failures label cmd
+    failures=""
+    for label in 'run2-backslash-n:echo x\\ngit commit' \
+                 'run2-backslash-t:echo x\\tgit commit' \
+                 'run4-two-backslashes:echo x\\\\ngit commit' \
+                 'windows-path:cd C:\\temp' \
+                 'run3-continuation-joins-words:echo x\\\ngit commit' \
+                 'run3-escaped-tab:echo x\\\tgit commit' \
+                 'run3-escaped-cr:echo x\\\rgit commit'; do
+        cmd="${label#*:}"
+        tmpdir=$(mktemp -d)
+        out=$(printf '{"tool_input":{"command":"%s"}}' "$cmd" | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+        rm -rf "$tmpdir"
+        { [ "$exit_code" -eq 0 ] && [ -z "$out" ]; } || failures="$failures [${label%%:*} -> exit=$exit_code]"
+    done
+    if [ -z "$failures" ]; then
+        pass "codex gate silent when a backslash escapes a literal letter rather than encoding whitespace"
+    else
+        fail "codex gate should exit 0 silent for escaped literal backslashes, got:$failures"
+    fi
+}
+
+# The allow-side mirror for the in-flight lane. Its block-path twin proves the
+# gate now SEES a relocation flag split across lines; this proves normalization
+# did not make the lane paranoid — a plain multi-line round-2 commit, on the
+# branch the handoff declares and carrying no relocation flag, still passes.
+test_codex_gate_allows_in_flight_multi_line_commit_on_declared_branch() {
+    local tmpdir out exit_code
+    tmpdir=$(mktemp -d)
+    (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init && git checkout -qB feat/581-lane) > /dev/null 2>&1
+    mkdir -p "$tmpdir/.reviews"
+    printf '{"status":"PENDING_RECHECK","round":2,"branch":"feat/581-lane"}' > "$tmpdir/.reviews/handoff.json"
+    out=$(printf '%s' '{"tool_input":{"command":"cd .\ngit commit -m \"round 2 fixes\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && [ -z "$out" ]; then
+        pass "codex gate ALLOWS (exit 0) an in-flight multi-line commit on the declared branch"
+    else
+        fail "codex gate should exit 0 silent for a multi-line PENDING_RECHECK commit on the declared branch, got exit=$exit_code out: $out"
+    fi
+}
+
+# The full backslash-run contract, k = 1..16, as a CANARY.
+#
+# Rows marked `2` are real invocations bash would run, and must block. Rows
+# marked `0` are not invocations, and must stay silent. Three rows — k = 7, 11,
+# 15, i.e. k = 3 (mod 4) — are ACCEPTED FALSE DENIALS: bash invokes nothing
+# there, but a literal backslash survives normalization and gives `\bgit` the
+# non-word character it needs.
+#
+# Those three rows assert wrong-but-accepted behavior ON PURPOSE, and that is
+# why this is a canary rather than a guard. If one of them starts ALLOWING, the
+# limitation has been fixed — this test fails, and whoever fixed it is forced to
+# update the known-limits paragraph in the hook and this table together. An
+# acceptance that is not pinned outlives the reason for accepting it.
+#
+# Sol demonstrated a sed-only second pairing pass that would close k = 3 (mod 4)
+# without needing command position; it is declined on complexity grounds, not
+# impossibility, and recorded on #581 as the fix path.
+test_codex_gate_backslash_run_contract() {
+    local tmpdir out exit_code failures k bs expected verb
+    failures=""
+    verb="com""mit"
+    for k in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+        case $((k % 4)) in
+            1) expected=2 ;;   # control escape survives -> real invocation
+            3) expected=2 ;;   # k=3 is a continuation (0); 7/11/15 are the accepted FPs
+            *) expected=0 ;;
+        esac
+        [ "$k" -eq 3 ] && expected=0
+        bs=$(printf '%*s' "$k" '' | tr ' ' '\\')
+        tmpdir=$(mktemp -d)
+        out=$(printf '{"tool_input":{"command":"echo x%sngit %s -m y"}}' "$bs" "$verb" \
+            | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+        rm -rf "$tmpdir"
+        [ "$exit_code" -eq "$expected" ] || failures="$failures [k=$k want=$expected got=$exit_code]"
+    done
+    if [ -z "$failures" ]; then
+        pass "codex gate matches the k=1..16 backslash-run contract, including the three accepted false denials"
+    else
+        fail "backslash-run contract drifted (a k=3-mod-4 row flipping to 0 means the limitation was FIXED — update the hook comment and this table):$failures"
+    fi
+}
+
+# Control for the fix above: decoding \n to `;` must NOT start blocking
+# multi-line commands that never commit. This is the regression the
+# normalization most plausibly causes.
+test_codex_gate_silent_on_multi_line_non_commit_command() {
+    local tmpdir out exit_code
+    tmpdir=$(mktemp -d)
+    out=$(printf '%s' '{"tool_input":{"command":"cd foo\nls -la"}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && [ -z "$out" ]; then
+        pass "codex gate silent on a multi-line command that never commits"
+    else
+        fail "codex gate should exit 0 silent for a multi-line non-commit command, got exit=$exit_code out: $out"
+    fi
+}
+
+# Control for the ORDER of the two transforms: normalization runs BEFORE the
+# quoted-span masking, so a verb living inside a quoted string still collapses
+# to the Q placeholder and stays allowed. Without this ordering the fix would
+# widen the prose false-positive class (#588) past the accepted margin.
+test_codex_gate_silent_when_multi_line_verb_is_inside_quotes() {
+    local tmpdir out exit_code
+    tmpdir=$(mktemp -d)
+    out=$(printf '%s' '{"tool_input":{"command":"echo \"cd foo\ngit commit\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && [ -z "$out" ]; then
+        pass "codex gate silent when a multi-line quoted string merely contains the verb"
+    else
+        fail "codex gate should exit 0 silent when the verb is inside a quoted span, got exit=$exit_code out: $out"
+    fi
+}
+
+# The #533 in-flight lane reads the same COMMAND_VALUE, so it inherited the same
+# bypass: a relocation flag separated from `git` by a JSON-escaped newline never
+# reached the catcher, because the structural match failed upstream first.
+# Normalizing once, before both consumers, closes it in both places.
+test_codex_gate_blocks_in_flight_relocation_token_across_lines() {
+    local tmpdir out exit_code
+    tmpdir=$(mktemp -d)
+    (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init && git checkout -qB feat/581-lane) > /dev/null 2>&1
+    mkdir -p "$tmpdir/.reviews"
+    printf '{"status":"PENDING_RECHECK","round":2,"branch":"feat/581-lane"}' > "$tmpdir/.reviews/handoff.json"
+    out=$(printf '%s' '{"tool_input":{"command":"git --work-tree=/tmp \\\n  commit -m \"x\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 2 ]; then
+        pass "codex gate BLOCKS (exit 2) an in-flight relocation flag split from git by \\n"
+    else
+        fail "codex gate should exit 2 for a line-split in-flight relocation flag, got exit=$exit_code out: $out"
+    fi
+}
+
 test_codex_gate_blocks_commit_without_review
 test_codex_gate_allows_commit_with_certified_review
 test_codex_gate_allows_commit_with_reviewed_status
@@ -4199,6 +4458,15 @@ test_codex_gate_blocks_in_flight_commit_declared_on_trunk
 test_codex_gate_blocks_in_flight_commit_with_relocation_token
 test_codex_gate_blocks_in_flight_commit_with_equals_relocation_tokens
 test_codex_gate_does_not_advertise_an_inline_bypass
+test_codex_gate_blocks_commit_split_across_lines
+test_codex_gate_silent_on_shapes_that_do_not_invoke_git
+test_codex_gate_backslash_run_contract
+test_codex_gate_allows_certified_commit_split_across_lines
+test_codex_gate_silent_on_escaped_literal_backslashes
+test_codex_gate_allows_in_flight_multi_line_commit_on_declared_branch
+test_codex_gate_silent_on_multi_line_non_commit_command
+test_codex_gate_silent_when_multi_line_verb_is_inside_quotes
+test_codex_gate_blocks_in_flight_relocation_token_across_lines
 
 # ---- codex-review-stop-check.sh tests ----
 # Fable self-enforcement audit finding: a full SDLC workflow can complete —


### PR DESCRIPTION
Closes #581.

## The hole

`hooks/codex-gate-check.sh` matched against `COMMAND_VALUE` as it arrives on the **JSON wire**, where a real newline is the two characters `\` `n` and a tab is `\` `t`. A `git commit` whose invocation was split across lines therefore never matched the detector — and committed without cross-model review.

## The fix

Decode the wire escapes to their bash-equivalent separators before detection:

| wire | bash meaning | normalized to |
|---|---|---|
| `\n` | terminates a command | `;` |
| `\t` | token separator | space |
| run-3 (`\` + newline) | line continuation — bash removes it entirely | deleted |

A `\001` sentinel pairing pass runs first, so an **escaped literal backslash** (`\\n`, two chars of text) is never confused with a **control escape** (`\n`, a newline). That distinction was the P1 against the first cut.

## How the shapes were classified

Not by assertion — by a **bash oracle**: a fake `git` on `PATH` that prints when it is invoked. Every candidate shape is run for real, and the hook is correct exactly when it agrees with what the oracle observed. This reclassified two of six shapes I had claimed were bypasses; they invoke nothing, and the suite had been codifying two false denials.

A **canary** test pins `k = 1..16` backslash-run behaviour against that oracle. It asserts the current wrong-but-accepted outcomes deliberately, so it fails if they are ever fixed — forcing the comment and the table to move together with the code.

## Known limits, stated in the hook

- Unicode `\uXXXX` escapes are not decoded.
- Backslash runs of **k ≡ 3 (mod 4)** before `n` (7, 11, 15) produce a false denial. Declined on **complexity, not impossibility** — Sol disproved my original "only cure is bypass-shaped" rationale and prototyped a sed-only fix through k = 16. The fix path is recorded on #581.

## The #588 prose false-positive edge moves, and the hook says so

Measured against `origin/main`, not asserted:

```
single-line prose      blocked before, blocked now   — unchanged
newline-separated      allowed before, allowed now   — unchanged (\n → ';' separates rather than fuses)
tab-separated          allowed before, BLOCKED now   — WIDENED
```

Tab-separated prose is newly caught, because a tab genuinely is a bash separator and the detector cannot see the surrounding text is prose. Accepted within the already-accepted #588 class: fails closed, costs a rephrase.

## Verification

`tests/test-hooks.sh` — **225 pass / 0 fail**.

CI is also the deferred **GNU-sed / Linux** verification; the normalizer was only exercisable against BSD sed locally.

## Review status — landing at round 7 with an objection recorded

Rounds 1–4 found real defects and changed code each time. Rounds **5, 6, 7 changed no behaviour at all**; every blocker was a sentence in a comment.

Sol's round-7 verdict is **NOT CERTIFIED, 9/10**, blocking on:

> lines 172-176 inaccurately claim no widening and an overall narrowing.

**Refuted on evidence, recorded rather than actioned.** The quoted claim is not in the tree — `grep -E 'neither opened|nor widened|narrowed it'` over both files returns nothing. Sol's own grep output, reproduced inside its report, shows line 172 onward is already the corrected table above. Its prescription is verbatim what lines 176–185 already say. There is no edit available that satisfies it.

Fable set the termination rule before the round: rounds 1–4 converged; 5–7 are a sentence ratchet that is structurally unbounded, since every directional claim is itself a fresh falsifiable assertion. Only a **new behaviour defect** — a wrong exit code, not a wrong sentence — restarts review. This is not one.

Full record: `.reviews/handoff.json`, `.reviews/581-sol-r7.md`.
