### PR TITLE
fix(codex-gate): refuse a review leg typed outside its launcher (#590)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Run codex-gate command-position tests (#588)
         run: ./tests/test-codex-gate-command-position.sh
 
+      - name: Run review-leg launcher requirement tests (#590)
+        run: ./tests/test-review-leg-launcher-required.sh
+
       - name: Run hook stdin boundedness tests (#491 Class 2)
         run: ./tests/test-hook-stdin-bounded.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for your interest in improving the SDLC Harness!
    ./tests/test-workflow-triggers.sh && ./tests/test-cusum.sh && \
    ./tests/test-stats.sh && ./tests/test-hooks.sh && \
    ./tests/test-codex-gate-command-position.sh && \
+   ./tests/test-review-leg-launcher-required.sh && \
    ./tests/test-token-spike.sh && \
    ./tests/test-codex-progress-wrapper.sh && \
    ./tests/test-run-review-leg.sh && \
@@ -196,6 +197,7 @@ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
 ./tests/test-stats.sh
 ./tests/test-hooks.sh
 ./tests/test-codex-gate-command-position.sh
+./tests/test-review-leg-launcher-required.sh
 ./tests/test-hook-stdin-bounded.sh
 ./tests/test-token-spike.sh
 ./tests/test-codex-progress-wrapper.sh

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -547,8 +547,15 @@ GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
 # the installed CLI; `ex` and `exe` do NOT resolve, so this is an alias list,
 # not prefix inference, and enumerating the two is exact rather than a guess.
 #
-# The subcommand must be a COMPLETE token: `exec-server` is a different
-# subcommand and the trailing class excludes the `-` that starts it.
+# The subcommand must be a COMPLETE token, and the boundary that proves it is a
+# SHELL token boundary — whitespace, a metacharacter that actually ends a
+# command, or end of line. Not "any non-word character", which is what round 4
+# found: `$`, `.` and `=` all CONTINUE a token, so `SUFFIX=-server; codex
+# exec$SUFFIX --help` runs `codex exec-server` and was refused. `exec-server` is
+# a different subcommand and `-` was already excluded; `$`, `.` and `=` are the
+# same case and are excluded the same way, by naming the boundary instead of
+# negating a word class.
+GATE_CODEX_END="([[:space:]]|[;&|)}<>]|\$)"
 #
 # NO OPTION MAY APPEAR BETWEEN `codex` AND THE SUBCOMMAND. That is a deliberate
 # accepted limit, and it is the design this lane arrived at rather than the one
@@ -576,7 +583,7 @@ GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
 # an option. Accepted and REPORTED rather than fixed — a missed leg is an
 # accident this lane did not catch; a false refusal blocks the maintainer's own
 # review. #601 is the precedent for a measured accepted limit.
-GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex[[:space:]]+(exec|e)([^A-Za-z0-9_-]|\$)"
+GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex[[:space:]]+(exec|e)${GATE_CODEX_END}"
 # Wrappers, but NOT the greedy GATE_SKIP the git lane uses. GATE_SKIP consumes
 # the wrapped command and restarts matching at its arguments, which turned
 # `env echo codex exec`, `env grep codex exec README.md` and

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -556,7 +556,37 @@ GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
 #
 # The subcommand must be a COMPLETE token: `exec-server` is a different
 # subcommand and the trailing class excludes the `-` that starts it.
-GATE_CODEX_OPT="(\\s+-${GATE_WORD}*(\\s+${GATE_WORD}+)?)*"
+# OPTION ARITY IS EXPLICIT, because "option, then maybe a value" backtracks.
+# Round 2: from a directory containing `exec/`, `codex -C exec review --help`
+# is a valid invocation of `codex review` — and the lane refused it, because
+# the OPTIONAL value could be given up so that `exec` matched as the
+# subcommand. An optional trailing word is not a grammar; it is two grammars
+# and the engine picks whichever refuses.
+#
+# So the value-taking options are named and MUST consume their value, which
+# makes `-C exec review` unambiguous: `exec` is -C's value, `review` is the
+# subcommand, no match. `codex --model gpt-5.6-sol exec` still matches because
+# the value is consumed and `exec` follows it.
+#
+# The list is codex's own value-taking globals (`codex --help`). An unlisted
+# value-taking option would be read as a boolean and its value as a command
+# name, which fails to match — a false negative, the direction this lane is
+# allowed to be wrong in.
+# BOTH classes are enumerated, from `codex --help`, and a generic branch for
+# either one is what made round 2's finding possible. A generic `--word`
+# boolean matches `--model`, which frees its value to be read as the
+# subcommand — and the engine will find that parse, because the alternative
+# (consume the value, then look for a subcommand) fails outright and a failed
+# branch never wins. Optionality is not a grammar; it is two grammars, and
+# whichever refuses is the one that gets picked.
+#
+# An option in neither list fails to match, so the whole predicate fails and
+# the command is ALLOWED. That is the deliberate direction: a missed leg is an
+# accident this lane did not catch, a false refusal blocks the maintainer's own
+# review. `remote-auth-token-env` precedes `remote` so the longer name wins.
+GATE_CODEX_VALOPT="(-[cimpsCa]|--(config|enable|disable|remote-auth-token-env|remote|image|model|local-provider|profile|sandbox|cd|add-dir|ask-for-approval))"
+GATE_CODEX_BOOLOPT="(-[hV]|--(strict-config|oss|approve-for-me|dangerously-bypass-approvals-and-sandbox|dangerously-bypass-hook-trust|search|no-alt-screen|help|version))"
+GATE_CODEX_OPT="(\\s+(${GATE_CODEX_VALOPT}(=|[[:space:]]+)${GATE_WORD}+|${GATE_CODEX_BOOLOPT}))*"
 GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex${GATE_CODEX_OPT}\\s+(exec|e)([^A-Za-z0-9_-]|\$)"
 # Wrappers, but NOT the greedy GATE_SKIP the git lane uses. GATE_SKIP consumes
 # the wrapped command and restarts matching at its arguments, which turned
@@ -574,7 +604,18 @@ GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex${GATE_CODEX_OPT}\\s+(exec|e)([^A-Za-z0-9
 # whose argument happens to look like a command — accepted, because a false
 # refusal here blocks the maintainer's own review leg, and the git lane's
 # greedy form is what produced three of round 1's eight findings.
-GATE_CODEX_WRAP="(${GATE_WRAPPER}([[:space:]]+(-${GATE_WORD}*|[0-9]+[smhd]?|${GATE_ASSIGN}))*[[:space:]]+)*"
+# Round 2: `env -u FOO codex exec`, `xargs -I X codex exec` and
+# `sudo -u USER codex exec` are real legs that reached codex, and the carry let
+# them through — it admitted dash-tokens but not the TEXTUAL value a wrapper
+# option takes. The git twins of all three are refused, so this was the lane's
+# own gap, not an inherited one.
+#
+# The value-taking wrapper options are named rather than admitted generically.
+# A generic "option then any word" recreates exactly the wrapped-prose false
+# positives round 1 found: `env -i echo codex exec` would read `echo` as -i's
+# value and refuse a command that runs echo.
+GATE_WRAP_VALOPT="-[ugUISnPdske]"
+GATE_CODEX_WRAP="(${GATE_WRAPPER}([[:space:]]+(${GATE_WRAP_VALOPT}[[:space:]]+${GATE_WORD}+|-${GATE_WORD}*|[0-9]+[smhd]?|${GATE_ASSIGN}))*[[:space:]]+)*"
 if printf '%s' "$MASKED_COMMAND" | grep -qE \
     "${GATE_ANCHOR}[[:space:]]*${GATE_PREFIX}${GATE_CODEX_WRAP}${GATE_CODEX}"; then
     # Read the RAW command for the launcher: masking collapses quoted text, and

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -542,9 +542,41 @@ GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
 # records about the merge gate: this sees commands issued through the Claude
 # Code Bash tool. A leg launched from a terminal never meets it. It is an
 # accident-catcher for the path where the accident actually happened.
-GATE_CODEX="(${GATE_WORD}*/)?codex\\s+(${GATE_WORD}+\\s+)*exec\\b"
+# The subcommand is `exec` or its DECLARED alias `e` — `codex --help` lists
+# "exec ... [aliases: e]", and `codex e --help` prints exec's help. Verified on
+# the installed CLI; `ex` and `exe` do NOT resolve, so this is an alias list,
+# not prefix inference, and enumerating the two is exact rather than a guess.
+#
+# Between `codex` and the subcommand, only OPTION tokens may appear — a token
+# starting with `-`, optionally followed by its value. The first version
+# accepted any words there, which made `codex review exec` (where `exec` is the
+# review PROMPT), `codex help exec`, and `codex exec-server --help` all
+# refusals. Those are the #588 false-positive class reappearing in a new lane,
+# and they are what this bound removes.
+#
+# The subcommand must be a COMPLETE token: `exec-server` is a different
+# subcommand and the trailing class excludes the `-` that starts it.
+GATE_CODEX_OPT="(\\s+-${GATE_WORD}*(\\s+${GATE_WORD}+)?)*"
+GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex${GATE_CODEX_OPT}\\s+(exec|e)([^A-Za-z0-9_-]|\$)"
+# Wrappers, but NOT the greedy GATE_SKIP the git lane uses. GATE_SKIP consumes
+# the wrapped command and restarts matching at its arguments, which turned
+# `env echo codex exec`, `env grep codex exec README.md` and
+# `env ls /tmp/codex exec` into refusals: the wrapper runs echo/grep/ls, and
+# `codex exec` is their ARGUMENT, not a command.
+#
+# What a wrapper may carry between itself and `codex` is therefore enumerated
+# rather than skipped: its own options, an option's value, a bare number
+# (`timeout 300`), or an assignment (`env FOO=1`). None of those is a command
+# name, so the wrapped-prose shapes above stop matching while `env codex exec`,
+# `timeout 300 codex exec` and `nice -n 5 codex exec` stay caught.
+#
+# This is narrower than the git lane on purpose. It costs coverage of a wrapper
+# whose argument happens to look like a command — accepted, because a false
+# refusal here blocks the maintainer's own review leg, and the git lane's
+# greedy form is what produced three of round 1's eight findings.
+GATE_CODEX_WRAP="(${GATE_WRAPPER}([[:space:]]+(-${GATE_WORD}*|[0-9]+[smhd]?|${GATE_ASSIGN}))*[[:space:]]+)*"
 if printf '%s' "$MASKED_COMMAND" | grep -qE \
-    "${GATE_ANCHOR}[[:space:]]*${GATE_PREFIX}(${GATE_WRAPPER}[[:space:]]+${GATE_SKIP})*${GATE_CODEX}"; then
+    "${GATE_ANCHOR}[[:space:]]*${GATE_PREFIX}${GATE_CODEX_WRAP}${GATE_CODEX}"; then
     # Read the RAW command for the launcher: masking collapses quoted text, and
     # the launcher's path can legitimately appear in a quoted argument.
     if ! printf '%s' "$COMMAND_VALUE" | grep -q 'run-review-leg\.sh'; then

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -547,75 +547,51 @@ GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
 # the installed CLI; `ex` and `exe` do NOT resolve, so this is an alias list,
 # not prefix inference, and enumerating the two is exact rather than a guess.
 #
-# Between `codex` and the subcommand, only OPTION tokens may appear — a token
-# starting with `-`, optionally followed by its value. The first version
-# accepted any words there, which made `codex review exec` (where `exec` is the
-# review PROMPT), `codex help exec`, and `codex exec-server --help` all
-# refusals. Those are the #588 false-positive class reappearing in a new lane,
-# and they are what this bound removes.
-#
 # The subcommand must be a COMPLETE token: `exec-server` is a different
 # subcommand and the trailing class excludes the `-` that starts it.
-# OPTION ARITY IS EXPLICIT, because "option, then maybe a value" backtracks.
-# Round 2: from a directory containing `exec/`, `codex -C exec review --help`
-# is a valid invocation of `codex review` — and the lane refused it, because
-# the OPTIONAL value could be given up so that `exec` matched as the
-# subcommand. An optional trailing word is not a grammar; it is two grammars
-# and the engine picks whichever refuses.
 #
-# So the value-taking options are named and MUST consume their value, which
-# makes `-C exec review` unambiguous: `exec` is -C's value, `review` is the
-# subcommand, no match. `codex --model gpt-5.6-sol exec` still matches because
-# the value is consumed and `exec` follows it.
+# NO OPTION MAY APPEAR BETWEEN `codex` AND THE SUBCOMMAND. That is a deliberate
+# accepted limit, and it is the design this lane arrived at rather than the one
+# it started with. Rounds 1-3 of cross-model review scored 3/10, 6/10, 4/10 —
+# every round's findings were facts about codex's own option grammar, not about
+# the accident being guarded:
 #
-# The list is codex's own value-taking globals (`codex --help`). An unlisted
-# value-taking option would be read as a boolean and its value as a command
-# name, which fails to match — a false negative, the direction this lane is
-# allowed to be wrong in.
-# BOTH classes are enumerated, from `codex --help`, and a generic branch for
-# either one is what made round 2's finding possible. A generic `--word`
-# boolean matches `--model`, which frees its value to be read as the
-# subcommand — and the engine will find that parse, because the alternative
-# (consume the value, then look for a subcommand) fails outright and a failed
-# branch never wins. Optionality is not a grammar; it is two grammars, and
-# whichever refuses is the one that gets picked.
+#   round 2  an option's value is not the subcommand   `codex -C exec review`
+#   round 3  compact short values                      `codex -mfoo exec`
+#   round 3  `-h`/`-V` terminate and never dispatch    `codex -h exec`
+#   round 3  `--image` is VARIADIC                     `codex -i a exec`
+#   round 3  per-wrapper arity is not one letter class `xargs -E` vs `sudo -n`
 #
-# An option in neither list fails to match, so the whole predicate fails and
-# the command is ALLOWED. That is the deliberate direction: a missed leg is an
-# accident this lane did not catch, a false refusal blocks the maintainer's own
-# review. `remote-auth-token-env` precedes `remote` so the longer name wins.
-GATE_CODEX_VALOPT="(-[cimpsCa]|--(config|enable|disable|remote-auth-token-env|remote|image|model|local-provider|profile|sandbox|cd|add-dir|ask-for-approval))"
-GATE_CODEX_BOOLOPT="(-[hV]|--(strict-config|oss|approve-for-me|dangerously-bypass-approvals-and-sandbox|dangerously-bypass-hook-trust|search|no-alt-screen|help|version))"
-GATE_CODEX_OPT="(\\s+(${GATE_CODEX_VALOPT}(=|[[:space:]]+)${GATE_WORD}+|${GATE_CODEX_BOOLOPT}))*"
-GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex${GATE_CODEX_OPT}\\s+(exec|e)([^A-Za-z0-9_-]|\$)"
+# Each fix was correct and each opened new surface, because modelling a CLI's
+# option grammar in a regex is building a parser — the thing #533 ruled out,
+# arriving one round at a time. The score never converged.
+#
+# So the gap is closed instead of described. `codex` must be followed directly
+# by the subcommand. This catches BOTH accidents that motivated the lane, and
+# the reason is not luck: `codex exec --model X -c key=value "prompt"` is the
+# shape the CLI is actually used in, with options AFTER the subcommand. An
+# option BEFORE it is a shape no leg in this repo has ever been typed in.
+#
+# What it costs: `codex --model X exec` escapes, as does every wrapper carrying
+# an option. Accepted and REPORTED rather than fixed — a missed leg is an
+# accident this lane did not catch; a false refusal blocks the maintainer's own
+# review. #601 is the precedent for a measured accepted limit.
+GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex[[:space:]]+(exec|e)([^A-Za-z0-9_-]|\$)"
 # Wrappers, but NOT the greedy GATE_SKIP the git lane uses. GATE_SKIP consumes
 # the wrapped command and restarts matching at its arguments, which turned
 # `env echo codex exec`, `env grep codex exec README.md` and
 # `env ls /tmp/codex exec` into refusals: the wrapper runs echo/grep/ls, and
 # `codex exec` is their ARGUMENT, not a command.
 #
-# What a wrapper may carry between itself and `codex` is therefore enumerated
-# rather than skipped: its own options, an option's value, a bare number
-# (`timeout 300`), or an assignment (`env FOO=1`). None of those is a command
-# name, so the wrapped-prose shapes above stop matching while `env codex exec`,
-# `timeout 300 codex exec` and `nice -n 5 codex exec` stay caught.
+# A wrapper may therefore carry NOTHING between itself and `codex`, for the
+# same reason codex may carry no option before its subcommand: round 3 showed a
+# shared letter class is wrong in both directions at once (`xargs -E` takes a
+# value and was missed; `sudo -n` is boolean and caused a false refusal), and a
+# per-wrapper arity table is the same parser by another name.
 #
-# This is narrower than the git lane on purpose. It costs coverage of a wrapper
-# whose argument happens to look like a command — accepted, because a false
-# refusal here blocks the maintainer's own review leg, and the git lane's
-# greedy form is what produced three of round 1's eight findings.
-# Round 2: `env -u FOO codex exec`, `xargs -I X codex exec` and
-# `sudo -u USER codex exec` are real legs that reached codex, and the carry let
-# them through — it admitted dash-tokens but not the TEXTUAL value a wrapper
-# option takes. The git twins of all three are refused, so this was the lane's
-# own gap, not an inherited one.
-#
-# The value-taking wrapper options are named rather than admitted generically.
-# A generic "option then any word" recreates exactly the wrapped-prose false
-# positives round 1 found: `env -i echo codex exec` would read `echo` as -i's
-# value and refuse a command that runs echo.
-GATE_WRAP_VALOPT="-[ugUISnPdske]"
-GATE_CODEX_WRAP="(${GATE_WRAPPER}([[:space:]]+(${GATE_WRAP_VALOPT}[[:space:]]+${GATE_WORD}+|-${GATE_WORD}*|[0-9]+[smhd]?|${GATE_ASSIGN}))*[[:space:]]+)*"
+# `env codex exec` and `sudo codex exec` stay caught. `timeout 300 codex exec`
+# and `nice -n 5 codex exec` no longer do — accepted with the rest.
+GATE_CODEX_WRAP="(${GATE_WRAPPER}[[:space:]]+)*"
 if printf '%s' "$MASKED_COMMAND" | grep -qE \
     "${GATE_ANCHOR}[[:space:]]*${GATE_PREFIX}${GATE_CODEX_WRAP}${GATE_CODEX}"; then
     # Read the RAW command for the launcher: masking collapses quoted text, and

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -516,6 +516,45 @@ GATE_PREFIX="((${GATE_ASSIGN}|${GATE_REDIR})[[:space:]]+)*"
 # independently by the `&` anchor either way). GATE_WORD is interpolated here
 # rather than re-inlined, so the six sites cannot drift apart.
 GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
+# --- A REVIEW LEG MUST RUN THROUGH ITS LAUNCHER (#590 completion) -----------
+#
+# This lane sits ABOVE the git-commit detector because that detector exits 0
+# on any command it does not recognise, and `codex exec` is one of them.
+#
+# `scripts/run-review-leg.sh` has prevented the codex stdin hang since #590
+# closed, and its own header says a leg typed outside it "has no owner and no
+# status". On 2026-08-14 two legs for PR #606 were typed by hand anyway, in a
+# session that had read that header: one hung at 39 bytes with no
+# `< /dev/null` (the exact signature #590 was closed on) and one exhausted its
+# budget with no verdict. Written knowledge that is not applied is what this
+# closes; the repo's answer to that has historically been to write it down
+# again, and PR #606 is a seven-round demonstration of why that fails.
+#
+# The predicate is deliberately the smallest one that catches the accident:
+# `codex` in command position followed by `exec`, allowed if the command names
+# the launcher. It reuses this gate's existing anchoring rather than adding a
+# second notion of command position, so the two cannot drift — and it reads
+# MASKED_COMMAND, so a quoted mention (`grep "codex exec" docs`) is already a Q
+# by the time it gets here and cannot false-fire. That is the #588 defect class
+# and it is not being repeated.
+#
+# NOT A SECURITY BOUNDARY, and the distinction is the one #479's ROADMAP note
+# records about the merge gate: this sees commands issued through the Claude
+# Code Bash tool. A leg launched from a terminal never meets it. It is an
+# accident-catcher for the path where the accident actually happened.
+GATE_CODEX="(${GATE_WORD}*/)?codex\\s+(${GATE_WORD}+\\s+)*exec\\b"
+if printf '%s' "$MASKED_COMMAND" | grep -qE \
+    "${GATE_ANCHOR}[[:space:]]*${GATE_PREFIX}(${GATE_WRAPPER}[[:space:]]+${GATE_SKIP})*${GATE_CODEX}"; then
+    # Read the RAW command for the launcher: masking collapses quoted text, and
+    # the launcher's path can legitimately appear in a quoted argument.
+    if ! printf '%s' "$COMMAND_VALUE" | grep -q 'run-review-leg\.sh'; then
+        echo "CROSS-MODEL REVIEW GATE: run the review leg through scripts/run-review-leg.sh, not 'codex exec' directly." >&2
+        echo "  scripts/run-review-leg.sh OUTPUT_FILE PROMPT [EXTRA_CODEX_ARGS...]" >&2
+        echo "The launcher gives the child /dev/null on stdin whatever the caller inherited, and its own exit status IS the leg's verdict — 0 completed, non-zero failed, nothing by your deadline means inspect and relaunch. A leg typed by hand has no owner and no status: its fate is unknown immediately, and by wall clock a hang is identical to a slow review. Measured 2026-08-14 on PR #606: one hand-typed leg hung at 39 bytes, a second returned no verdict. $BYPASS_NOTE" >&2
+        exit 2
+    fi
+fi
+
 if ! printf '%s' "$MASKED_COMMAND" | grep -qE \
     "${GATE_ANCHOR}[[:space:]]*${GATE_PREFIX}(${GATE_WRAPPER}[[:space:]]+${GATE_SKIP})*${GATE_GIT}"; then
     exit 0

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -555,7 +555,11 @@ GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
 # a different subcommand and `-` was already excluded; `$`, `.` and `=` are the
 # same case and are excluded the same way, by naming the boundary instead of
 # negating a word class.
-GATE_CODEX_END="([[:space:]]|[;&|)}<>]|\$)"
+# `}` is NOT in the set. It only closes a group as a RESERVED WORD, which needs
+# a preceding `;` or newline and its own whitespace — as a bare character it is
+# an ordinary one, and `bash -c 'printf "[%s]" exec}foo'` prints one word. So
+# `codex exec}foo --help` was refused. `)` stays: it is a real metacharacter.
+GATE_CODEX_END="([[:space:]]|[;&|)<>]|\$)"
 #
 # NO OPTION MAY APPEAR BETWEEN `codex` AND THE SUBCOMMAND. That is a deliberate
 # accepted limit, and it is the design this lane arrived at rather than the one
@@ -599,16 +603,24 @@ GATE_CODEX="(${GATE_WORD}*/)?\\\\?codex[[:space:]]+(exec|e)${GATE_CODEX_END}"
 # `env codex exec` and `sudo codex exec` stay caught. `timeout 300 codex exec`
 # and `nice -n 5 codex exec` no longer do — accepted with the rest.
 GATE_CODEX_WRAP="(${GATE_WRAPPER}[[:space:]]+)*"
+# THERE IS NO LAUNCHER ESCAPE HATCH, and removing it is what closed the last
+# hole. This lane used to allow any command whose RAW text mentioned
+# `run-review-leg.sh`, so that the launcher itself could not be refused. That
+# check made `scripts/run-review-leg.sh out p && codex exec "q"` allowed — the
+# lane satisfied by MENTIONING the launcher rather than using it.
+#
+# It was never needed. A launcher invocation is `scripts/run-review-leg.sh
+# OUTPUT PROMPT [args]` and contains no `codex exec` token at all, so the
+# predicate does not match it in the first place. Verified by neutralising the
+# check and re-running: all three real launcher shapes stay ALLOWED, and the
+# `&&` bypass becomes REFUSED. The whole hatch was dead weight that could only
+# ever be wrong. The suite still pins the launcher shapes as allowed.
 if printf '%s' "$MASKED_COMMAND" | grep -qE \
     "${GATE_ANCHOR}[[:space:]]*${GATE_PREFIX}${GATE_CODEX_WRAP}${GATE_CODEX}"; then
-    # Read the RAW command for the launcher: masking collapses quoted text, and
-    # the launcher's path can legitimately appear in a quoted argument.
-    if ! printf '%s' "$COMMAND_VALUE" | grep -q 'run-review-leg\.sh'; then
-        echo "CROSS-MODEL REVIEW GATE: run the review leg through scripts/run-review-leg.sh, not 'codex exec' directly." >&2
-        echo "  scripts/run-review-leg.sh OUTPUT_FILE PROMPT [EXTRA_CODEX_ARGS...]" >&2
-        echo "The launcher gives the child /dev/null on stdin whatever the caller inherited, and its own exit status IS the leg's verdict — 0 completed, non-zero failed, nothing by your deadline means inspect and relaunch. A leg typed by hand has no owner and no status: its fate is unknown immediately, and by wall clock a hang is identical to a slow review. Measured 2026-08-14 on PR #606: one hand-typed leg hung at 39 bytes, a second returned no verdict. $BYPASS_NOTE" >&2
-        exit 2
-    fi
+    echo "CROSS-MODEL REVIEW GATE: run the review leg through scripts/run-review-leg.sh, not 'codex exec' directly." >&2
+    echo "  scripts/run-review-leg.sh OUTPUT_FILE PROMPT [EXTRA_CODEX_ARGS...]" >&2
+    echo "The launcher gives the child /dev/null on stdin whatever the caller inherited, and its own exit status IS the leg's verdict — 0 completed, non-zero failed, nothing by your deadline means inspect and relaunch. A leg typed by hand has no owner and no status: its fate is unknown immediately, and by wall clock a hang is identical to a slow review. Measured 2026-08-14 on PR #606: one hand-typed leg hung at 39 bytes, a second returned no verdict. $BYPASS_NOTE" >&2
+    exit 2
 fi
 
 if ! printf '%s' "$MASKED_COMMAND" | grep -qE \

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -531,8 +531,11 @@ GATE_SKIP="((${GATE_WORD}|[<>]\\||[<>]&|&>|[[:space:]])*[[:space:]])?"
 # again, and PR #606 is a seven-round demonstration of why that fails.
 #
 # The predicate is deliberately the smallest one that catches the accident:
-# `codex` in command position followed by `exec`, allowed if the command names
-# the launcher. It reuses this gate's existing anchoring rather than adding a
+# `codex` in command position followed by `exec`. There is no launcher escape
+# hatch — see the note above the match itself for why one was never needed and
+# why the one that existed was deleted.
+#
+# It reuses this gate's existing anchoring rather than adding a
 # second notion of command position, so the two cannot drift — and it reads
 # MASKED_COMMAND, so a quoted mention (`grep "codex exec" docs`) is already a Q
 # by the time it gets here and cannot false-fire. That is the #588 defect class

--- a/scripts/measure-consult-rate.py
+++ b/scripts/measure-consult-rate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Count how often the driver consults Fable BEFORE acting (GH #504).
+
+The number #504 asks for: "How often does an Opus driver proceed on a
+judgement call without consulting Fable?"
+
+CAVEAT, and it is the whole reason this file carries a docstring: the
+denominator here is TURNS, not decision episodes. One Fable ruling followed by
+twenty implementation turns scores as nineteen misses, and the policy this
+measures ("Fable rules on design, priority and sequencing before an approach is
+committed") does not ask for a consult before every edit. Cross-model review of
+the first numbers this produced ruled the metric directional, not load-bearing.
+Read it as an alarm about the current topology, never as a verdict on a model.
+
+Usage: scripts/measure-consult-rate.py [transcript-dir]
+"""
+import json, glob, os, re, sys, collections
+
+DIR = sys.argv[1] if len(sys.argv) > 1 else os.path.expanduser(
+    "~/.claude/projects/-Users-stefanayala-claude-sdlc-wizard")
+SUBSTANTIVE = {"Edit", "Write", "NotebookEdit"}
+SUB_BASH = re.compile(r"\bgit\s+commit\b|\bgh\s+(pr|issue)\s+(create|merge|comment|edit)\b")
+
+
+def user_text(ev):
+    """The visible text of a real user message, or None if this is not one."""
+    m = ev.get("message") or {}
+    c = m.get("content")
+    if isinstance(c, list):
+        if any(p.get("type") == "tool_result" for p in c):
+            return None            # a tool result is not a user turn
+        c = " ".join(p.get("text", "") for p in c if p.get("type") == "text")
+    if not isinstance(c, str) or not c.strip():
+        return None
+    if c.startswith("[SYSTEM NOTIFICATION"):
+        return None
+    stripped = re.sub(r"<system-reminder>.*?</system-reminder>", "", c, flags=re.S).strip()
+    return stripped or None
+
+
+def turns():
+    for f in sorted(glob.glob(os.path.join(DIR, "*.jsonl")), key=os.path.getmtime):
+        cur = None
+        for line in open(f, errors="replace"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except ValueError:
+                continue
+            if ev.get("type") == "user":
+                t = user_text(ev)
+                if t is None:
+                    continue
+                if cur:
+                    yield cur
+                # ask length is retained so the reported slices are reproducible
+                cur = {"ask": len(t), "order": [], "file": os.path.basename(f), "model": None}
+                continue
+            if cur is None or ev.get("type") != "assistant":
+                continue
+            msg = ev.get("message") or {}
+            # attribute the turn to the model that ACTED in it, so a mixed
+            # corpus cannot be read as one model's behaviour
+            if msg.get("model") and cur["model"] is None:
+                cur["model"] = msg["model"]
+            for p in msg.get("content", []) or []:
+                if p.get("type") != "tool_use":
+                    continue
+                name = p.get("name")
+                if name == "advisor":
+                    cur["order"].append("C")
+                elif name == "Agent" and "fable" in json.dumps(p.get("input") or {}).lower():
+                    cur["order"].append("C")
+                elif name in SUBSTANTIVE:
+                    cur["order"].append("S")
+                elif name == "Bash" and SUB_BASH.search((p.get("input") or {}).get("command", "")):
+                    cur["order"].append("S")
+        if cur:
+            yield cur
+
+
+def report(label, rows):
+    acted = [r for r in rows if "S" in r["order"]]
+    if not acted:
+        return
+    pre = sum(1 for r in acted if "C" in r["order"][:r["order"].index("S")])
+    after = sum(1 for r in acted
+                if "C" in r["order"] and r["order"].index("C") > r["order"].index("S"))
+    never = sum(1 for r in acted if "C" not in r["order"])
+    print("%-30s turns=%4d  pre=%3d (%4.1f%%)  after=%3d  never=%4d (%4.1f%%)"
+          % (label, len(acted), pre, 100 * pre / len(acted), after,
+             never, 100 * never / len(acted)))
+
+
+ROWS = list(turns())
+print("corpus: %s\ntotal real user turns: %d\n" % (DIR, len(ROWS)))
+report("ALL", ROWS)
+report("ask >= 200 chars", [r for r in ROWS if r["ask"] >= 200])
+report("ask >= 80 chars", [r for r in ROWS if r["ask"] >= 80])
+report("ask < 80 chars", [r for r in ROWS if r["ask"] < 80])
+print("\n-- by acting model (a near-identical rate across models means this is a\n"
+      "   harness property, not one model's defect) --")
+for m in sorted({r["model"] for r in ROWS if r["model"]}):
+    report(m, [r for r in ROWS if r["model"] == m])
+print("\n-- by session (clustering check: one dominant transcript is not a corpus) --")
+for f in sorted({r["file"] for r in ROWS}):
+    report(f[:8], [r for r in ROWS if r["file"] == f])

--- a/tests/test-review-leg-launcher-required.sh
+++ b/tests/test-review-leg-launcher-required.sh
@@ -119,17 +119,19 @@ expect_allowed "an unrelated command" \
 expect_refused "the declared 'e' alias — a real leg the first version allowed" \
     'codex e "review this"'
 
-expect_refused "the alias behind an option that takes a value" \
+# ACCEPTED LIMIT (round 4 redesign): an option between `codex` and the
+# subcommand escapes by design. See the header of the lane in the hook.
+expect_allowed "ACCEPTED LIMIT: the alias behind an option that takes a value" \
     'codex --model gpt-5.6-sol e "review this"'
 
-expect_refused "the alias behind a short option" \
+expect_allowed "ACCEPTED LIMIT: the alias behind a short option" \
     'codex -m gpt-5.6-sol e "review"'
 
 # Wrappers must still be caught when they wrap codex ITSELF.
 expect_refused "env wrapping codex directly" \
     'env codex exec "review"'
 
-expect_refused "timeout wrapping codex directly" \
+expect_allowed "ACCEPTED LIMIT: a wrapper carrying its own argument" \
     'timeout 300 codex exec "review"'
 
 expect_refused "an assignment prefix" \
@@ -161,13 +163,22 @@ expect_allowed "a wrapper running grep, with the words as its pattern" \
 expect_allowed "a wrapper running ls, with the words as its path" \
     'env ls /tmp/codex exec'
 
-# --- round 2 of cross-model review -----------------------------------------
-# Its verdict was NOT CERTIFIED 6/10, two blockers, both demonstrated against
-# the real CLI. It also reproduced the ten-row parity table exactly, which is
-# what confirmed the other five round-1 findings as inherited.
+# --- rounds 2 and 3, and the redesign they forced ---------------------------
+#
+# Round 2 (6/10) and round 3 (4/10) each demonstrated real facts about codex's
+# option grammar that an option-aware predicate got wrong. The score across
+# three rounds went 3 -> 6 -> 4: every fix was correct and every fix opened new
+# surface, because modelling a CLI's grammar in a regex is building the parser
+# #533 rules out. The gap is now closed instead of described.
+#
+# EVERY command either round demonstrated is still a row. The ones an
+# option-aware predicate would have had to reason about are now ALLOWED, each
+# an accepted limit rather than a defect — the direction this lane is permitted
+# to be wrong in.
 
-# An option's VALUE is not the subcommand. From a directory containing `exec/`,
-# `codex -C exec review --help` is a valid invocation of `codex review`.
+# Round 2: an option's VALUE is not the subcommand. From a directory containing
+# `exec/`, `codex -C exec review --help` is a valid invocation of `codex
+# review`. Correct then and correct now, by a rule with no arity in it.
 expect_allowed "an option value named exec, short form" \
     'codex -C exec review --help'
 
@@ -180,52 +191,74 @@ expect_allowed "an option value named exec, long form" \
 expect_allowed "an option value named e" \
     'codex --model e review'
 
-# ...but the value being consumed must not hide a real leg behind it.
-expect_refused "a consumed option value followed by the real subcommand" \
+expect_allowed "ACCEPTED LIMIT: an option value, then the real subcommand" \
     'codex --model gpt-5.6-sol exec "review"'
 
-expect_refused "short option with value, then the alias" \
+expect_allowed "ACCEPTED LIMIT: short option with value, then the alias" \
     'codex -c model_reasoning_effort=high e "review"'
 
-# Wrapper options that take a TEXTUAL value. All three reach codex.
-expect_refused "env -u FOO wrapping a leg" \
+# Round 2: wrapper options that take a TEXTUAL value. All three reach codex.
+# Round 3 then showed the letter class fixing these was wrong in BOTH
+# directions at once — `xargs -E` takes a value and was missed, `sudo -n` is
+# boolean and produced a false refusal. A wrapper now carries nothing.
+expect_allowed "ACCEPTED LIMIT: env -u FOO wrapping a leg" \
     'env -u FOO codex exec "review"'
 
-expect_refused "xargs -I X wrapping a leg" \
+expect_allowed "ACCEPTED LIMIT: xargs -I X wrapping a leg" \
     'xargs -I X codex exec "review"'
 
-expect_refused "sudo -u USER wrapping a leg" \
+expect_allowed "ACCEPTED LIMIT: sudo -u USER wrapping a leg" \
     'sudo -u USER codex exec "review"'
 
-# The wrapper carry must NOT admit a generic word, or round 1's wrapped-prose
-# false positives come straight back.
+expect_allowed "ACCEPTED LIMIT: xargs -E, the uppercase value option round 3 found" \
+    'xargs -E EOF codex exec "review"'
+
+expect_allowed "sudo -n is BOOLEAN and echo is the command — a false refusal, now gone" \
+    'sudo -n echo codex exec'
+
 expect_allowed "env -i running echo, with the words as its argument" \
     'env -i echo codex exec'
 
-# --- pinning the two enumerated option lists --------------------------------
-# Found by falsifying the arity fix before submitting it, not by a reviewer.
-# These rows exist because both lists are transcribed from `codex --help`, and
-# a CLI change is the way they rot silently: a boolean that becomes
-# value-taking turns into a false REFUSAL, the direction that blocks the
-# maintainer's own review leg.
-
-expect_refused "a boolean long option consumes no value" \
-    'codex --oss exec "review"'
-
-expect_refused "a boolean short option consumes no value" \
+# Round 3: `-h`/`-V` and their long forms terminate at global help/version and
+# never dispatch exec. An option-aware predicate refused all four. There is no
+# leg here to miss — these are pure false positives that the redesign removes.
+expect_allowed "-h terminates at global help and never dispatches exec" \
     'codex -h exec'
 
-expect_refused "a value-taking option in its = form" \
+expect_allowed "--help terminates at global help" \
+    'codex --help exec'
+
+expect_allowed "-V terminates at version" \
+    'codex -V exec'
+
+expect_allowed "--version terminates at version" \
+    'codex --version exec'
+
+# Round 3: compact short-option values. `codex -mfoo exec --help` reaches exec.
+expect_allowed "ACCEPTED LIMIT: compact short value, model flag" \
+    'codex -mfoo exec --help'
+
+expect_allowed "ACCEPTED LIMIT: compact short value, sandbox flag" \
+    'codex -sread-only exec --help'
+
+expect_allowed "ACCEPTED LIMIT: compact short value, relocation flag" \
+    'codex -C/tmp exec --help'
+
+expect_allowed "ACCEPTED LIMIT: compact short value, approval flag" \
+    'codex -anever exec --help'
+
+# Round 3: `--image`/`-i` is VARIADIC, so `codex -i a exec --help` prints
+# top-level help — `exec` is a second image operand, not the subcommand. The
+# single-value model got this backwards. No arity model, no way to be wrong.
+expect_allowed "-i is variadic, so a following 'exec' is another operand" \
+    'codex -i a exec --help'
+
+# A boolean long option is an option like any other: it escapes.
+expect_allowed "ACCEPTED LIMIT: a boolean long option before the subcommand" \
+    'codex --oss exec "review"'
+
+expect_allowed "ACCEPTED LIMIT: the = form of a value-taking option" \
     'codex --sandbox=read-only exec "review"'
-
-expect_refused "a value-taking option whose value is a path" \
-    'codex --add-dir /tmp exec "review"'
-
-expect_allowed "-a takes a value, so a following 'exec' is that value" \
-    'codex -a exec review'
-
-expect_allowed "--add-dir takes a value, so a following 'e' is that value" \
-    'codex --add-dir e review'
 
 # Forced failure for the hoisted guard above. Runs LAST so it cannot mask a
 # real result, and only under the sentinel the guard sets.

--- a/tests/test-review-leg-launcher-required.sh
+++ b/tests/test-review-leg-launcher-required.sh
@@ -161,6 +161,72 @@ expect_allowed "a wrapper running grep, with the words as its pattern" \
 expect_allowed "a wrapper running ls, with the words as its path" \
     'env ls /tmp/codex exec'
 
+# --- round 2 of cross-model review -----------------------------------------
+# Its verdict was NOT CERTIFIED 6/10, two blockers, both demonstrated against
+# the real CLI. It also reproduced the ten-row parity table exactly, which is
+# what confirmed the other five round-1 findings as inherited.
+
+# An option's VALUE is not the subcommand. From a directory containing `exec/`,
+# `codex -C exec review --help` is a valid invocation of `codex review`.
+expect_allowed "an option value named exec, short form" \
+    'codex -C exec review --help'
+
+expect_allowed "an option value named exec, model flag" \
+    'codex -m exec review --help'
+
+expect_allowed "an option value named exec, long form" \
+    'codex --cd exec review --help'
+
+expect_allowed "an option value named e" \
+    'codex --model e review'
+
+# ...but the value being consumed must not hide a real leg behind it.
+expect_refused "a consumed option value followed by the real subcommand" \
+    'codex --model gpt-5.6-sol exec "review"'
+
+expect_refused "short option with value, then the alias" \
+    'codex -c model_reasoning_effort=high e "review"'
+
+# Wrapper options that take a TEXTUAL value. All three reach codex.
+expect_refused "env -u FOO wrapping a leg" \
+    'env -u FOO codex exec "review"'
+
+expect_refused "xargs -I X wrapping a leg" \
+    'xargs -I X codex exec "review"'
+
+expect_refused "sudo -u USER wrapping a leg" \
+    'sudo -u USER codex exec "review"'
+
+# The wrapper carry must NOT admit a generic word, or round 1's wrapped-prose
+# false positives come straight back.
+expect_allowed "env -i running echo, with the words as its argument" \
+    'env -i echo codex exec'
+
+# --- pinning the two enumerated option lists --------------------------------
+# Found by falsifying the arity fix before submitting it, not by a reviewer.
+# These rows exist because both lists are transcribed from `codex --help`, and
+# a CLI change is the way they rot silently: a boolean that becomes
+# value-taking turns into a false REFUSAL, the direction that blocks the
+# maintainer's own review leg.
+
+expect_refused "a boolean long option consumes no value" \
+    'codex --oss exec "review"'
+
+expect_refused "a boolean short option consumes no value" \
+    'codex -h exec'
+
+expect_refused "a value-taking option in its = form" \
+    'codex --sandbox=read-only exec "review"'
+
+expect_refused "a value-taking option whose value is a path" \
+    'codex --add-dir /tmp exec "review"'
+
+expect_allowed "-a takes a value, so a following 'exec' is that value" \
+    'codex -a exec review'
+
+expect_allowed "--add-dir takes a value, so a following 'e' is that value" \
+    'codex --add-dir e review'
+
 # Forced failure for the hoisted guard above. Runs LAST so it cannot mask a
 # real result, and only under the sentinel the guard sets.
 if [ -n "${LAUNCHER_SUITE_FORCE_FAILURE:-}" ]; then

--- a/tests/test-review-leg-launcher-required.sh
+++ b/tests/test-review-leg-launcher-required.sh
@@ -298,6 +298,37 @@ expect_refused "naming the launcher does not license a hand-typed leg beside it"
 expect_refused "...nor does mentioning it in an argument" \
     'echo scripts/run-review-leg.sh; codex exec "q"'
 
+# --- round 6: array data reads as command position --------------------------
+# `words=(codex exec)` assigns two array elements and invokes nothing, but the
+# gate refuses it: GATE_SEP treats `(` as a command separator and the boundary
+# set treats `)` as ending the token. Both are SHARED machinery.
+#
+# INHERITED, not introduced, and measured rather than argued. Run from a tree
+# with NO .reviews/ — so detection alone decides, because with a valid handoff
+# present the git lane exits 0 on the ARTIFACT and that is not an allow:
+#
+#     shape                        codex     git
+#     words=(codex exec)           REFUSE    REFUSE
+#     words=(...) ; ls             REFUSE    REFUSE
+#     words="codex exec"           ALLOW     ALLOW
+#     (codex exec)                 REFUSE    REFUSE
+#     { codex exec; }              REFUSE    REFUSE
+#
+# Fixing it means knowing that `(` opens an ARRAY VALUE rather than a subshell,
+# which is context a regex does not have — and it would have to change the
+# shared anchor, which is blocker condition (3) for the git lane. So the shape
+# is PINNED as it behaves, in both lanes, rather than silently left untested.
+expect_refused "INHERITED LIMIT: array data reads as command position" \
+    'words=(codex exec)'
+
+# shellcheck disable=SC2016  # the UNEXPANDED text is the input under test
+expect_refused "INHERITED LIMIT: ...and a launcher call after it is refused too" \
+    'words=(codex exec)
+scripts/run-review-leg.sh .reviews/out.md "${words[*]}" --model gpt-5.6-sol'
+
+expect_allowed "a STRING assignment is not command position — the boundary case" \
+    'words="codex exec"'
+
 # A boolean long option is an option like any other: it escapes.
 expect_allowed "ACCEPTED LIMIT: a boolean long option before the subcommand" \
     'codex --oss exec "review"'

--- a/tests/test-review-leg-launcher-required.sh
+++ b/tests/test-review-leg-launcher-required.sh
@@ -253,6 +253,31 @@ expect_allowed "ACCEPTED LIMIT: compact short value, approval flag" \
 expect_allowed "-i is variadic, so a following 'exec' is another operand" \
     'codex -i a exec --help'
 
+# --- round 4: the token boundary must be a SHELL boundary -------------------
+# The redesign scored 8/10 with one blocker. `[^A-Za-z0-9_-]` treats `$`, `.`
+# and `=` as ending the token, but all three CONTINUE it. The first row below
+# is the reviewer's: bash expands it to a valid `codex exec-server --help`.
+
+# shellcheck disable=SC2016  # the UNEXPANDED text is the input under test
+expect_allowed "an expansion continues the token — this runs codex exec-server" \
+    'SUFFIX=-server; codex exec$SUFFIX --help'
+
+expect_allowed "a dot continues the token" \
+    'codex exec.foo'
+
+expect_allowed "an equals continues the token" \
+    'codex exec=foo'
+
+# ...and the boundaries that ARE real must still catch a leg.
+expect_refused "end of line is a boundary" \
+    'codex exec'
+
+expect_refused "a redirection immediately after the subcommand is a boundary" \
+    'codex exec>out.md'
+
+expect_refused "a semicolon is a boundary" \
+    'codex e;true'
+
 # A boolean long option is an option like any other: it escapes.
 expect_allowed "ACCEPTED LIMIT: a boolean long option before the subcommand" \
     'codex --oss exec "review"'

--- a/tests/test-review-leg-launcher-required.sh
+++ b/tests/test-review-leg-launcher-required.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# A review leg typed by hand instead of run through the launcher must be
+# refused (#590 completion — the launcher existed, was documented, and was
+# bypassed anyway).
+#
+# WHY THIS EXISTS RATHER THAN MORE DOCUMENTATION
+#
+# `scripts/run-review-leg.sh` has prevented the stdin hang since #590 closed.
+# Its own header says "A leg typed ad hoc, outside this script, has no owner
+# and no status." On 2026-08-14 two review legs for PR #606 were typed by hand
+# anyway, in a session that had read that header: the first hung at 39 bytes
+# with no `< /dev/null` — the exact signature #590 was closed on — and the
+# second ran without the launcher's discipline and exhausted its budget with
+# no verdict. The maintainer's reaction was "are we failing to do reviews is
+# it breaking or hanging".
+#
+# Written knowledge that is not applied is the failure this closes. Both
+# review legs ruled independently that the fix is mechanization, and that it
+# belongs on the ALREADY-REGISTERED Bash gate rather than as a new hook.
+#
+# WHAT IT DOES NOT CLAIM. This is an accident-catcher for the in-harness Bash
+# path, not a security boundary. A leg launched outside the Claude Code Bash
+# tool never meets this hook, exactly as `merge-gate-check.sh` never meets a
+# merge driven through a browser. Say that narrowly rather than overclaiming
+# it, which is the error #479's ROADMAP note records.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HOOK="$REPO_ROOT/hooks/codex-gate-check.sh"
+PASSED=0
+FAILED=0
+
+# The suite must be able to report a regression to CI. Hoisted ABOVE every
+# definition, because a guard placed after the thing it guards is skipped by
+# any early exit that lands between them (#598 round 20).
+if [ -z "${LAUNCHER_SUITE_FORCE_FAILURE:-}" ]; then
+    if LAUNCHER_SUITE_FORCE_FAILURE=1 "$0" > /dev/null 2>&1; then
+        echo "FATAL: a forced failure still exited 0 — this suite cannot report a regression to CI" >&2
+        exit 1
+    fi
+fi
+
+pass() { PASSED=$((PASSED + 1)); printf '\033[0;32mPASS\033[0m: %s\n' "$1"; }
+fail() { FAILED=$((FAILED + 1)); printf '\033[0;31mFAIL\033[0m: %s\n' "$1"; }
+
+# Run the hook against one Bash command, exactly as Claude Code invokes it:
+# the command arrives as the "command" field of a JSON tool-input on stdin.
+# Exit 2 is a refusal; 0 is an allow.
+run_hook() {
+    python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1],"description":"d"}}))' "$1" \
+        | "$HOOK" > /dev/null 2>&1
+    echo $?
+}
+
+expect_refused() {
+    local desc="$1" cmd="$2" rc
+    rc=$(run_hook "$cmd")
+    if [ "$rc" = "2" ]; then
+        pass "refused: $desc"
+    else
+        fail "ALLOWED (exit $rc), must be refused: $desc — [$cmd]"
+    fi
+}
+
+expect_allowed() {
+    local desc="$1" cmd="$2" rc
+    rc=$(run_hook "$cmd")
+    if [ "$rc" = "0" ]; then
+        pass "allowed: $desc"
+    else
+        fail "REFUSED (exit $rc), must be allowed: $desc — [$cmd]"
+    fi
+}
+
+# --- the shapes that must be refused ---------------------------------------
+# These are real commands from the 2026-08-14 session, not invented ones.
+
+expect_refused "bare codex exec, no launcher and no /dev/null (the leg that hung)" \
+    'codex exec --model gpt-5.6-sol -c model_reasoning_effort=high "review this" > .reviews/out.md 2>&1'
+
+expect_refused "bare codex exec WITH < /dev/null — the redirect is not the point, ownership is" \
+    'codex exec --model gpt-5.6-sol "review this" < /dev/null > .reviews/out.md 2>&1'
+
+expect_refused "codex exec after a cd" \
+    'cd /tmp && codex exec --model gpt-5.6-sol "review"'
+
+expect_refused "codex exec as the second command in a chain" \
+    'git status; codex exec --model gpt-5.6-sol "review"'
+
+expect_refused "codex exec with the sandbox flag this repo uses" \
+    'codex exec --sandbox read-only --cd /Users/x "prompt" > out.md 2>&1'
+
+# --- the shapes that must still be allowed ----------------------------------
+
+expect_allowed "the launcher itself, which supplies /dev/null to its child" \
+    'scripts/run-review-leg.sh .reviews/out.md "review this" --model gpt-5.6-sol'
+
+expect_allowed "the launcher by absolute path" \
+    "$REPO_ROOT/scripts/run-review-leg.sh .reviews/out.md \"review\" --model gpt-5.6-sol"
+
+expect_allowed "prose that merely mentions the command — the #588 defect class, not repeated here" \
+    'grep -rn "codex exec" CLAUDE_CODE_SDLC_WIZARD.md'
+
+expect_allowed "a codex subcommand that is not exec" \
+    'codex --version'
+
+expect_allowed "an unrelated command" \
+    'ls -la scripts/'
+
+# Forced failure for the hoisted guard above. Runs LAST so it cannot mask a
+# real result, and only under the sentinel the guard sets.
+if [ -n "${LAUNCHER_SUITE_FORCE_FAILURE:-}" ]; then
+    fail "forced failure (LAUNCHER_SUITE_FORCE_FAILURE=1) — proves this suite can report one"
+fi
+
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+[ "$FAILED" -eq 0 ]

--- a/tests/test-review-leg-launcher-required.sh
+++ b/tests/test-review-leg-launcher-required.sh
@@ -278,6 +278,26 @@ expect_refused "a redirection immediately after the subcommand is a boundary" \
 expect_refused "a semicolon is a boundary" \
     'codex e;true'
 
+# --- round 5: two independent reviewers, one one-line defect each -----------
+# Both certified the round-4 design and each found a real blocker in it.
+
+# `}` is not a shell token boundary. It closes a group only as a RESERVED WORD,
+# which needs a preceding `;` or newline and its own whitespace; as a bare
+# character it is ordinary. `bash -c 'printf "[%s]" exec}foo'` prints one word.
+expect_allowed "a closing brace continues the token — it is not a metacharacter" \
+    'codex exec}foo --help'
+
+expect_allowed "an opening brace continues the token" \
+    'codex exec{foo --help'
+
+# The launcher escape hatch is GONE, and this is the shape that killed it: the
+# lane used to be satisfied by MENTIONING the launcher anywhere in the command.
+expect_refused "naming the launcher does not license a hand-typed leg beside it" \
+    'scripts/run-review-leg.sh out p && codex exec "q"'
+
+expect_refused "...nor does mentioning it in an argument" \
+    'echo scripts/run-review-leg.sh; codex exec "q"'
+
 # A boolean long option is an option like any other: it escapes.
 expect_allowed "ACCEPTED LIMIT: a boolean long option before the subcommand" \
     'codex --oss exec "review"'

--- a/tests/test-review-leg-launcher-required.sh
+++ b/tests/test-review-leg-launcher-required.sh
@@ -108,6 +108,59 @@ expect_allowed "a codex subcommand that is not exec" \
 expect_allowed "an unrelated command" \
     'ls -la scripts/'
 
+# --- round 1 of cross-model review: every shape it demonstrated, as a row ----
+#
+# The reviewer ran these against the hook and reported the exit status; each is
+# recorded here so the finding cannot come back silently. Its verdict was
+# NOT CERTIFIED 3/10 on the first version of this lane.
+
+# The declared alias. `codex --help` lists "exec ... [aliases: e]" and
+# `codex e --help` prints exec's help; `ex` and `exe` do not resolve.
+expect_refused "the declared 'e' alias — a real leg the first version allowed" \
+    'codex e "review this"'
+
+expect_refused "the alias behind an option that takes a value" \
+    'codex --model gpt-5.6-sol e "review this"'
+
+expect_refused "the alias behind a short option" \
+    'codex -m gpt-5.6-sol e "review"'
+
+# Wrappers must still be caught when they wrap codex ITSELF.
+expect_refused "env wrapping codex directly" \
+    'env codex exec "review"'
+
+expect_refused "timeout wrapping codex directly" \
+    'timeout 300 codex exec "review"'
+
+expect_refused "an assignment prefix" \
+    'FOO=bar codex exec "review"'
+
+expect_refused "codex by absolute path" \
+    '/usr/local/bin/codex exec "review"'
+
+expect_refused "escaped command name" \
+    '\codex exec "review"'
+
+# False positives the first version introduced — these invoke no review leg.
+# `exec` here is the review PROMPT, an argument, or a different subcommand.
+expect_allowed "codex review with 'exec' as the prompt" \
+    'codex review exec'
+
+expect_allowed "codex help exec" \
+    'codex help exec'
+
+expect_allowed "exec-server is a different subcommand, not a complete 'exec' token" \
+    'codex exec-server --help'
+
+expect_allowed "a wrapper running echo, with the words as its argument" \
+    'env echo codex exec'
+
+expect_allowed "a wrapper running grep, with the words as its pattern" \
+    'env grep codex exec README.md'
+
+expect_allowed "a wrapper running ls, with the words as its path" \
+    'env ls /tmp/codex exec'
+
 # Forced failure for the hoisted guard above. Runs LAST so it cannot mask a
 # real result, and only under the sentinel the guard sets.
 if [ -n "${LAUNCHER_SUITE_FORCE_FAILURE:-}" ]; then


### PR DESCRIPTION
## The failure

`scripts/run-review-leg.sh` has prevented the codex stdin hang since #590 closed. Its own header says a leg typed outside it *"has no owner and no status."*

On 2026-08-14 two review legs for PR #606 were typed by hand anyway, **in a session that had read that header**:

| attempt | what was missing | result |
|---|---|---|
| 1 | `< /dev/null` | hung at 39 bytes — the exact signature #590 was closed on |
| 2 | the launcher's discipline | exhausted its budget, returned no verdict |

The maintainer's reaction: *"are we failing to do reviews is it breaking or hanging."* Both attempts corrupted the review evidence for #606 before the third — through the launcher — completed first try and certified.

## Why a hook and not more documentation

The knowledge was written down, documented, and closed as an issue. It was not applied. This repo's historical response to unapplied knowledge is to write it down more emphatically in more places; PR #606 is a seven-round demonstration of why that fails.

Both review legs were asked independently and converged: mechanize this boundary, on the **already-registered** Bash gate rather than as a new hook.

Sol named the tension honestly rather than around it — the standing *"no new guard or tooling surface"* ruling is literally against this, and should yield, because **Rung 1's own stop condition is that review legs must not hang.** Tonight proves #590 is behaviourally incomplete despite being closed.

## The predicate

The smallest one that catches the accident: `codex` in command position followed by `exec`, allowed when the command names the launcher.

- Reuses the gate's existing `GATE_ANCHOR` / `GATE_PREFIX` / `GATE_WRAPPER` machinery rather than introducing a second notion of command position, so the two cannot drift.
- Reads `MASKED_COMMAND`, so a quoted mention (`grep "codex exec" docs`) is already a `Q` by the time it arrives — the #588 false-positive class is not repeated.
- Sits **above** the git-commit detector, which exits 0 on every command it does not recognise.

## What it does NOT claim

An accident-catcher for the Claude Code Bash path, **not a security boundary**. A leg launched from a terminal never meets this hook, exactly as `merge-gate-check.sh` never meets a merge driven through a browser. Stated narrowly on purpose — #479's ROADMAP note records what overclaiming here costs.

Two other limits are on the handoff rather than hidden: the launcher check is a substring match, so a command that mentions the launcher while invoking codex directly would pass (the alternative is the positive command parsing #533 ruled out); and `scripts/` does not ship, so consumers get the refusal without the launcher it names — that is #594, not fixed here.

## Verification

RED first: **5 failed / 5 passed** — exactly the five refusal rows failed, every allow row passed. GREEN **10/0**. The refusal rows are real commands from the session, not invented ones.

The suite carries the hoisted forced-failure guard from #598 round 20, placed above every definition, because a guard after the thing it guards is skipped by any early exit between them.

```
codex-gate-command-position   200/0  (166 rows oracle-measured)
review-leg-launcher-required   10/0
doc-consistency               137/0
cowork-drift                   30/0
compliance                    green
shellcheck                    clean on both files
```

Wired into CI next to the sibling suite.

Refs #590, #594.
