### PR TITLE
feat(review-leg): put the build in front of the reviewer (#613)

### DIFF
--- a/scripts/run-review-leg.sh
+++ b/scripts/run-review-leg.sh
@@ -64,6 +64,76 @@ shift
 
 : > "$OUTPUT"
 
+# ---------------------------------------------------------------------------
+# THE BUILD GOES IN FRONT OF THE REVIEWER (#613)
+#
+# PR #610 ran EIGHT review rounds with two independent reviewers while CI
+# `validate` was red the entire time. Both reviewers ran the test suites
+# directly and correctly reported them green — the guard that was failing was
+# one nobody was asked about, and the merge gate is what finally caught it.
+# That is a gate step discovered mid-merge, which #593 Rung 1's stop condition
+# names as a failure in so many words.
+#
+# Both reviewers then prescribed the same fix independently, and it is not more
+# diff scrutiny: "Seven rounds audited the diff; zero audited the build."
+#
+# So the build is stated where the reviewer reads, BEFORE the model's own
+# output. This is preflight, never a gate: a red build is REPORTED and the leg
+# proceeds. Deliberately so — a leg must stay launchable against known-red CI
+# when that is the point, and a preflight that can refuse to launch is a second
+# way for a review to not happen, which is the failure #590 exists to prevent.
+#
+# Every failure mode of the probe is absorbed. No `gh`, no auth, no network, no
+# PR for this branch: each records "unknown" and the review runs. `< /dev/null`
+# for the same reason it is on the exec line below, and a timeout because a
+# preflight that can hang has reintroduced #590 in the one place nobody would
+# look for it.
+{
+    echo "## CI STATUS (preflight, #613)"
+    echo
+    # `timeout` is GNU coreutils and is NOT on a stock macOS — this repo's
+    # primary machine has neither `timeout` nor `gtimeout`. Hardcoding it makes
+    # the probe report UNKNOWN forever on the maintainer's own laptop, silently,
+    # which is the failure mode this whole issue is about. Caught by the suite,
+    # not by review. So it is used when present and skipped when not: gh carries
+    # its own network timeouts, and the leg is background work whose status the
+    # caller already owns.
+    if command -v timeout > /dev/null 2>&1; then
+        CI_TIMEOUT="timeout 30"
+    elif command -v gtimeout > /dev/null 2>&1; then
+        CI_TIMEOUT="gtimeout 30"
+    else
+        CI_TIMEOUT=""
+    fi
+    # shellcheck disable=SC2086  # unquoted on purpose: empty means "no wrapper"
+    if CI_OUT=$($CI_TIMEOUT gh pr checks --required 2>&1 < /dev/null); then
+        echo "All required checks reported passing:"
+        echo
+        echo '```'
+        echo "$CI_OUT"
+        echo '```'
+    else
+        CI_RC=$?
+        if [ -n "$CI_OUT" ]; then
+            echo "NOT GREEN, or not determinable (gh exit $CI_RC). Raw output:"
+            echo
+            echo '```'
+            echo "$CI_OUT"
+            echo '```'
+        else
+            echo "UNKNOWN — \`gh pr checks\` produced nothing (exit $CI_RC)."
+            echo "No PR for this branch, no auth, no network, or gh unavailable."
+        fi
+    fi
+    echo
+    echo "**A certification verdict issued over a build that is not green, or"
+    echo "not determinable, is only valid if it says so and says why.** The"
+    echo "build is an input to your verdict, not background noise."
+    echo
+    echo "---"
+    echo
+} >> "$OUTPUT" 2>&1
+
 # `< /dev/null` is the whole prevention: the child gets EOF immediately and
 # proceeds to the model. Keep it on this line — it is not incidental.
 #

--- a/scripts/run-review-leg.sh
+++ b/scripts/run-review-leg.sh
@@ -141,6 +141,14 @@ shift
     ( set +e; gh pr checks --required > "$CI_RAW" 2>&1 < /dev/null; echo $? > "$CI_DONE" ) &
     CI_PROBE_PID=$!
     set +m
+    # `disown` or bash announces the kill in the reviewer's own output file:
+    #   ./scripts/run-review-leg.sh: line N: 34945 Terminated: 15  ( set +e; gh …
+    # printed by the shell's job-control notice, inside the CI STATUS block —
+    # noise, exposing this script's internals, in the one block the PR exists to
+    # make readable. Found by review running the real stall repro. The group
+    # kill still works after disown (it addresses the process group, not the
+    # job table) and the `wait` below absorbs the disowned-job error.
+    disown "$CI_PROBE_PID" 2>/dev/null || true
     CI_WAITED=0
     while [ ! -f "$CI_DONE" ] && [ "$CI_WAITED" -lt "$CI_PROBE_TIMEOUT" ]; do
         sleep 1

--- a/scripts/run-review-leg.sh
+++ b/scripts/run-review-leg.sh
@@ -123,8 +123,24 @@ shift
     # would then look stalled and burn the full deadline on every red build —
     # reporting "abandoned" for the one case it most needs to report. Caught by
     # the suite's red-build row regressing, not by reading this back.
+    #
+    # `set -m` is what makes the timeout path able to CLEAN UP. Without job
+    # control a `( … ) &` subshell shares this shell's process group, so the
+    # only thing killable by pid is the subshell itself — and killing that
+    # leaves `gh` running, reparented to PID 1. Review ran the real fixture and
+    # observed exactly that: the leg finished while the probe and its own child
+    # stayed alive. An earlier version of this comment claimed the orphan
+    # "exits on its own"; that was an unverified claim, and a genuinely stalled
+    # `gh` never does. Repeated timeouts would leak processes, descriptors and
+    # connections until a later leg could not launch.
+    #
+    # With job control the subshell becomes a process-group leader, so the
+    # negative-pid kill below reaches the whole group: subshell, `gh`, and
+    # anything `gh` spawned.
+    set -m
     ( set +e; gh pr checks --required > "$CI_RAW" 2>&1 < /dev/null; echo $? > "$CI_DONE" ) &
     CI_PROBE_PID=$!
+    set +m
     CI_WAITED=0
     while [ ! -f "$CI_DONE" ] && [ "$CI_WAITED" -lt "$CI_PROBE_TIMEOUT" ]; do
         sleep 1
@@ -134,9 +150,13 @@ shift
         CI_RC=$(cat "$CI_DONE")
         CI_OUT=$(cat "$CI_RAW" 2>/dev/null || true)
     else
-        # Abandoned, not awaited. The orphaned gh writes to a temp file nobody
-        # reads and exits on its own; the review is what matters.
-        kill "$CI_PROBE_PID" 2>/dev/null || true
+        # Kill the whole process GROUP, not the subshell. The negative pid is
+        # the point — see the `set -m` note above. TERM first, then KILL for
+        # anything that ignores it, then reap so no zombie survives us.
+        kill -TERM -- "-$CI_PROBE_PID" 2>/dev/null || kill -TERM "$CI_PROBE_PID" 2>/dev/null || true
+        sleep 1
+        kill -KILL -- "-$CI_PROBE_PID" 2>/dev/null || kill -KILL "$CI_PROBE_PID" 2>/dev/null || true
+        wait "$CI_PROBE_PID" 2>/dev/null || true
         CI_RC=124
         CI_OUT=""
         CI_TIMED_OUT=1

--- a/scripts/run-review-leg.sh
+++ b/scripts/run-review-leg.sh
@@ -91,29 +91,67 @@ shift
 {
     echo "## CI STATUS (preflight, #613)"
     echo
-    # `timeout` is GNU coreutils and is NOT on a stock macOS — this repo's
-    # primary machine has neither `timeout` nor `gtimeout`. Hardcoding it makes
-    # the probe report UNKNOWN forever on the maintainer's own laptop, silently,
-    # which is the failure mode this whole issue is about. Caught by the suite,
-    # not by review. So it is used when present and skipped when not: gh carries
-    # its own network timeouts, and the leg is background work whose status the
-    # caller already owns.
-    if command -v timeout > /dev/null 2>&1; then
-        CI_TIMEOUT="timeout 30"
-    elif command -v gtimeout > /dev/null 2>&1; then
-        CI_TIMEOUT="gtimeout 30"
+    # THE DEADLINE IS THIS SCRIPT'S OWN, and it depends on nothing.
+    #
+    # The first version reached for `timeout`, then fell back to running `gh`
+    # bare when neither `timeout` nor `gtimeout` was present — which is stock
+    # macOS, including this repo's own machine — on the reasoning that "gh
+    # carries its own network timeouts."
+    #
+    # That was an unverified claim and it is FALSE: gh 2.92 configures no
+    # overall HTTP timeout (cli/cli api/http_client.go, go-gh
+    # pkg/api/client_options.go). A stalled request would block here forever,
+    # before `exec codex` ever ran — #590, the precise failure this launcher
+    # exists to prevent, reintroduced by the preflight added to prevent a
+    # different one. The suite missed it because its stub always exited.
+    #
+    # So: no external timeout binary, and no trust in the child's own limits.
+    # The probe runs in the background writing its exit status to a marker
+    # file, and this loop waits a bounded number of seconds for that marker.
+    #
+    # A marker file rather than `kill -0` on the pid: a background job of this
+    # shell stays a zombie until it is waited on, so `kill -0` reports it alive
+    # after it has finished and the loop would never exit early. `wait -n`
+    # would do it but needs bash 4, and macOS ships bash 3.2.
+    CI_PROBE_TIMEOUT="${SDLC_CI_PROBE_TIMEOUT:-30}"
+    CI_RAW="${TMPDIR:-/tmp}/sdlc-ci-probe.$$.out"
+    CI_DONE="${TMPDIR:-/tmp}/sdlc-ci-probe.$$.done"
+    rm -f "$CI_RAW" "$CI_DONE"
+    # `set +e` inside the subshell is load-bearing: this script runs under
+    # `set -e`, and a non-zero `gh` (which is exactly what a RED build is)
+    # would otherwise kill the subshell before it wrote its marker. The probe
+    # would then look stalled and burn the full deadline on every red build —
+    # reporting "abandoned" for the one case it most needs to report. Caught by
+    # the suite's red-build row regressing, not by reading this back.
+    ( set +e; gh pr checks --required > "$CI_RAW" 2>&1 < /dev/null; echo $? > "$CI_DONE" ) &
+    CI_PROBE_PID=$!
+    CI_WAITED=0
+    while [ ! -f "$CI_DONE" ] && [ "$CI_WAITED" -lt "$CI_PROBE_TIMEOUT" ]; do
+        sleep 1
+        CI_WAITED=$((CI_WAITED + 1))
+    done
+    if [ -f "$CI_DONE" ]; then
+        CI_RC=$(cat "$CI_DONE")
+        CI_OUT=$(cat "$CI_RAW" 2>/dev/null || true)
     else
-        CI_TIMEOUT=""
+        # Abandoned, not awaited. The orphaned gh writes to a temp file nobody
+        # reads and exits on its own; the review is what matters.
+        kill "$CI_PROBE_PID" 2>/dev/null || true
+        CI_RC=124
+        CI_OUT=""
+        CI_TIMED_OUT=1
     fi
-    # shellcheck disable=SC2086  # unquoted on purpose: empty means "no wrapper"
-    if CI_OUT=$($CI_TIMEOUT gh pr checks --required 2>&1 < /dev/null); then
+    rm -f "$CI_RAW" "$CI_DONE"
+    if [ "${CI_TIMED_OUT:-0}" = "1" ]; then
+        echo "UNKNOWN — the check probe did not return within ${CI_PROBE_TIMEOUT}s and was abandoned."
+        echo "The build was NOT verified. Treat it as undetermined, not as green."
+    elif [ "$CI_RC" = "0" ]; then
         echo "All required checks reported passing:"
         echo
         echo '```'
         echo "$CI_OUT"
         echo '```'
     else
-        CI_RC=$?
         if [ -n "$CI_OUT" ]; then
             echo "NOT GREEN, or not determinable (gh exit $CI_RC). Raw output:"
             echo

--- a/tests/test-run-review-leg.sh
+++ b/tests/test-run-review-leg.sh
@@ -204,9 +204,11 @@ check_rc "an output file with no prompt is a usage error, exit 64" 64 "$rc"
 # of the reviewer, rather than asking for more diff scrutiny. "Seven rounds
 # audited the diff; zero audited the build — that is the whole fix."
 #
-# The stub `gh` mirrors codex's: it must also read stdin to EOF when asked, so
-# a probe that fails to supply EOF hangs here rather than passing quietly. A
-# launcher that can hang on its own preflight has reintroduced #590.
+# The `gh` stub these rows drive is defined at the top of this file, beside the
+# codex stub, so that every test above runs hermetically too. It mirrors codex's
+# in reading stdin to EOF when asked, so a probe that fails to supply EOF hangs
+# rather than passing quietly — a launcher that can hang on its own preflight
+# has reintroduced #590.
 
 out=$(new_leg)
 set +e
@@ -313,6 +315,18 @@ if grep -qiE 'UNKNOWN|timed out|deadline' "$out"; then
     pass "the abandoned probe is recorded, not silently omitted"
 else
     fail "the probe timed out silently — a reviewer cannot tell the build was never checked"
+fi
+
+# The kill must be SILENT in the reviewer's file. Without `disown`, bash prints
+# its job-termination notice — "Terminated: 15   ( set +e; gh pr checks …" —
+# into this very block, exposing the launcher's internals as noise in the one
+# place the PR exists to make readable. Review found it by running the repro;
+# the suite could not, because nothing asserted on it. Deleting `disown` now
+# turns this row red.
+if grep -qE 'Terminated|Killed' "$out"; then
+    fail "a shell job notice leaked into the CI STATUS block — the reviewer reads launcher internals"
+else
+    pass "the kill is silent in the reviewer's output"
 fi
 
 # ...and it must be KILLED, not merely walked away from. The first fix killed

--- a/tests/test-run-review-leg.sh
+++ b/tests/test-run-review-leg.sh
@@ -66,6 +66,32 @@ printf '%s' "${STUB_STDOUT:-}"
 exit "${STUB_EXIT:-0}"
 STUB
 chmod +x "$STUBDIR/codex"
+# The `gh` stub is installed HERE, before the FIRST test, not beside the
+# tests that drive it. Installed later, every earlier test ran the launcher
+# against the REAL `gh` — live API calls from a unit suite, and a result
+# that depends on the network and on whether this branch has a PR. Review
+# caught it; the suite was non-hermetic for its first six tests.
+cat > "$STUBDIR/gh" <<'STUB'
+#!/bin/bash
+if [ -n "$GH_STUB_READ_STDIN" ]; then
+    cat > /dev/null
+fi
+# GH_STUB_SLEEP: never return. A stalled network call, which is what gh does
+# on a hung request — it sets NO overall HTTP timeout (verified against
+# cli/cli v2.92 api/http_client.go and go-gh v2.13 client_options.go).
+if [ -n "${GH_STUB_SLEEP:-}" ]; then
+    # Record our own pid so the test can prove we were actually killed, not
+    # merely abandoned. A launcher that walks away from a live process leaks
+    # it — reported by review after running the real fixture and finding both
+    # this stub and its `sleep` reparented to PID 1 and still running.
+    [ -n "${GH_STUB_PIDFILE:-}" ] && echo $$ > "$GH_STUB_PIDFILE"
+    sleep "$GH_STUB_SLEEP"
+fi
+printf '%s' "${GH_STUB_STDOUT:-}"
+exit "${GH_STUB_EXIT:-0}"
+STUB
+chmod +x "$STUBDIR/gh"
+
 export PATH="$STUBDIR:$PATH"
 export STUB_READ_STDIN=1
 
@@ -181,26 +207,6 @@ check_rc "an output file with no prompt is a usage error, exit 64" 64 "$rc"
 # The stub `gh` mirrors codex's: it must also read stdin to EOF when asked, so
 # a probe that fails to supply EOF hangs here rather than passing quietly. A
 # launcher that can hang on its own preflight has reintroduced #590.
-cat > "$STUBDIR/gh" <<'STUB'
-#!/bin/bash
-if [ -n "$GH_STUB_READ_STDIN" ]; then
-    cat > /dev/null
-fi
-# GH_STUB_SLEEP: never return. A stalled network call, which is what gh does
-# on a hung request — it sets NO overall HTTP timeout (verified against
-# cli/cli v2.92 api/http_client.go and go-gh v2.13 client_options.go).
-if [ -n "${GH_STUB_SLEEP:-}" ]; then
-    # Record our own pid so the test can prove we were actually killed, not
-    # merely abandoned. A launcher that walks away from a live process leaks
-    # it — reported by review after running the real fixture and finding both
-    # this stub and its `sleep` reparented to PID 1 and still running.
-    [ -n "${GH_STUB_PIDFILE:-}" ] && echo $$ > "$GH_STUB_PIDFILE"
-    sleep "$GH_STUB_SLEEP"
-fi
-printf '%s' "${GH_STUB_STDOUT:-}"
-exit "${GH_STUB_EXIT:-0}"
-STUB
-chmod +x "$STUBDIR/gh"
 
 out=$(new_leg)
 set +e

--- a/tests/test-run-review-leg.sh
+++ b/tests/test-run-review-leg.sh
@@ -165,6 +165,94 @@ rc=$?
 set -e
 check_rc "an output file with no prompt is a usage error, exit 64" 64 "$rc"
 
+# ---------------------------------------------------------------------------
+# 7. CI STATUS IS AN INPUT TO THE REVIEW (#613).
+#
+# PR #610 ran eight review rounds with two independent reviewers while CI
+# `validate` was RED the whole time. Both reviewers ran the suites directly and
+# correctly reported them green; the failing guard was one nobody was asked
+# about. The merge gate caught it, which is a gate step discovered mid-merge —
+# a violation of #593 Rung 1's own stop condition.
+#
+# Both reviewers independently prescribed the same fix: put the build in front
+# of the reviewer, rather than asking for more diff scrutiny. "Seven rounds
+# audited the diff; zero audited the build — that is the whole fix."
+#
+# The stub `gh` mirrors codex's: it must also read stdin to EOF when asked, so
+# a probe that fails to supply EOF hangs here rather than passing quietly. A
+# launcher that can hang on its own preflight has reintroduced #590.
+cat > "$STUBDIR/gh" <<'STUB'
+#!/bin/bash
+if [ -n "$GH_STUB_READ_STDIN" ]; then
+    cat > /dev/null
+fi
+printf '%s' "${GH_STUB_STDOUT:-}"
+exit "${GH_STUB_EXIT:-0}"
+STUB
+chmod +x "$STUBDIR/gh"
+
+out=$(new_leg)
+set +e
+GH_STUB_STDOUT='validate	fail	1m	https://example/run' GH_STUB_EXIT=1 \
+GH_STUB_READ_STDIN=1 \
+STUB_STDOUT='VERDICT: CERTIFIED' STUB_EXIT=0 \
+    "$RUNNER" "$out" 'review this' >/dev/null 2>&1
+rc=$?
+set -e
+check_rc "a red build does not fail the leg — it is reported, not fatal" 0 "$rc"
+
+if grep -qiE 'CI STATUS' "$out"; then
+    pass "the leg's output carries a CI STATUS block"
+else
+    fail "no CI STATUS block in the leg output — the reviewer cannot see the build"
+fi
+
+if grep -qF 'validate' "$out"; then
+    pass "the failing check's name reaches the reviewer"
+else
+    fail "the failing check's name is absent from the leg output"
+fi
+
+# The block must precede the model's own output, or a reviewer reading top-down
+# forms its verdict before it ever sees the build.
+if [ "$(grep -n 'CI STATUS' "$out" | head -1 | cut -d: -f1)" -lt \
+     "$(grep -n 'VERDICT' "$out" | head -1 | cut -d: -f1)" ]; then
+    pass "the CI STATUS block precedes the model's output"
+else
+    fail "the CI STATUS block does not precede the model's output"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. An unavailable `gh` must not take the leg down with it. The probe is
+# preflight, not the payload: no PR, no auth, no network, and the review still
+# runs — with the fact recorded rather than silently omitted.
+out=$(new_leg)
+set +e
+GH_STUB_STDOUT='' GH_STUB_EXIT=127 \
+STUB_STDOUT='VERDICT: CERTIFIED' STUB_EXIT=0 \
+    "$RUNNER" "$out" 'review this' >/dev/null 2>&1
+rc=$?
+set -e
+check_rc "an unavailable gh does not fail the leg" 0 "$rc"
+
+if grep -qiE 'CI STATUS' "$out"; then
+    pass "an unavailable gh still records a CI STATUS block"
+else
+    fail "an unavailable gh left no CI STATUS block — silently omitted"
+fi
+
+# ---------------------------------------------------------------------------
+# 9. The codex exit status still governs, with the probe in front of it. If the
+# preflight could mask the verdict, #590's whole mechanism is gone.
+out=$(new_leg)
+set +e
+GH_STUB_STDOUT='validate	pass	1m	url' GH_STUB_EXIT=0 \
+STUB_STDOUT='boom' STUB_EXIT=7 \
+    "$RUNNER" "$out" 'review this' >/dev/null 2>&1
+rc=$?
+set -e
+check_rc "the leg's exit status still governs, probe notwithstanding" 7 "$rc"
+
 echo ""
 echo "=== Results ==="
 echo "Passed: $PASS"

--- a/tests/test-run-review-leg.sh
+++ b/tests/test-run-review-leg.sh
@@ -190,6 +190,11 @@ fi
 # on a hung request — it sets NO overall HTTP timeout (verified against
 # cli/cli v2.92 api/http_client.go and go-gh v2.13 client_options.go).
 if [ -n "${GH_STUB_SLEEP:-}" ]; then
+    # Record our own pid so the test can prove we were actually killed, not
+    # merely abandoned. A launcher that walks away from a live process leaks
+    # it — reported by review after running the real fixture and finding both
+    # this stub and its `sleep` reparented to PID 1 and still running.
+    [ -n "${GH_STUB_PIDFILE:-}" ] && echo $$ > "$GH_STUB_PIDFILE"
     sleep "$GH_STUB_SLEEP"
 fi
 printf '%s' "${GH_STUB_STDOUT:-}"
@@ -275,9 +280,10 @@ check_rc "the leg's exit status still governs, probe notwithstanding" 7 "$rc"
 #
 # So the deadline is the launcher's own, enforced with nothing but bash.
 out=$(new_leg)
+probe_pidfile="$(dirname "$out")/probe.pid"
 start=$(date +%s)
 set +e
-GH_STUB_SLEEP=120 SDLC_CI_PROBE_TIMEOUT=2 \
+GH_STUB_SLEEP=120 GH_STUB_PIDFILE="$probe_pidfile" SDLC_CI_PROBE_TIMEOUT=2 \
 STUB_STDOUT='VERDICT: CERTIFIED' STUB_EXIT=0 \
     "$RUNNER" "$out" 'review this' >/dev/null 2>&1
 rc=$?
@@ -301,6 +307,24 @@ if grep -qiE 'UNKNOWN|timed out|deadline' "$out"; then
     pass "the abandoned probe is recorded, not silently omitted"
 else
     fail "the probe timed out silently — a reviewer cannot tell the build was never checked"
+fi
+
+# ...and it must be KILLED, not merely walked away from. The first fix killed
+# the subshell, which left `gh` itself running, reparented to PID 1. An earlier
+# known_limits entry claimed "it exits on its own"; that was an unverified
+# claim, and a genuinely stalled `gh` never does. Repeated timeouts would leak
+# processes, descriptors and connections until later legs cannot launch.
+sleep 1
+if [ -f "$probe_pidfile" ]; then
+    probe_pid=$(cat "$probe_pidfile")
+    if kill -0 "$probe_pid" 2>/dev/null; then
+        kill -9 "$probe_pid" 2>/dev/null || true
+        fail "the timed-out probe (pid $probe_pid) is still alive — abandoned, not killed"
+    else
+        pass "the timed-out probe was killed, not left running"
+    fi
+else
+    fail "the probe never recorded its pid — cannot prove it was killed"
 fi
 
 echo ""

--- a/tests/test-run-review-leg.sh
+++ b/tests/test-run-review-leg.sh
@@ -186,6 +186,12 @@ cat > "$STUBDIR/gh" <<'STUB'
 if [ -n "$GH_STUB_READ_STDIN" ]; then
     cat > /dev/null
 fi
+# GH_STUB_SLEEP: never return. A stalled network call, which is what gh does
+# on a hung request — it sets NO overall HTTP timeout (verified against
+# cli/cli v2.92 api/http_client.go and go-gh v2.13 client_options.go).
+if [ -n "${GH_STUB_SLEEP:-}" ]; then
+    sleep "$GH_STUB_SLEEP"
+fi
 printf '%s' "${GH_STUB_STDOUT:-}"
 exit "${GH_STUB_EXIT:-0}"
 STUB
@@ -252,6 +258,50 @@ STUB_STDOUT='boom' STUB_EXIT=7 \
 rc=$?
 set -e
 check_rc "the leg's exit status still governs, probe notwithstanding" 7 "$rc"
+
+# ---------------------------------------------------------------------------
+# 10. A STALLED PROBE MUST NOT HANG THE LEG.
+#
+# The first version of the CI probe fell back to a bare `gh pr checks` when
+# neither `timeout` nor `gtimeout` was present — which is the case on stock
+# macOS, including this repo's own machine — and justified it with "gh carries
+# its own network timeouts."
+#
+# That was an unverified claim and it is FALSE. gh 2.92 configures no overall
+# HTTP timeout (cli/cli api/http_client.go, go-gh pkg/api/client_options.go).
+# A stalled request would therefore block before `exec codex` ever ran: #590,
+# the exact failure the launcher exists to prevent, reintroduced by the fix
+# for #613 and hidden because the stub always exited.
+#
+# So the deadline is the launcher's own, enforced with nothing but bash.
+out=$(new_leg)
+start=$(date +%s)
+set +e
+GH_STUB_SLEEP=120 SDLC_CI_PROBE_TIMEOUT=2 \
+STUB_STDOUT='VERDICT: CERTIFIED' STUB_EXIT=0 \
+    "$RUNNER" "$out" 'review this' >/dev/null 2>&1
+rc=$?
+set -e
+elapsed=$(( $(date +%s) - start ))
+check_rc "a stalled CI probe does not fail the leg" 0 "$rc"
+
+if [ "$elapsed" -lt 30 ]; then
+    pass "the stalled probe is abandoned on a deadline (${elapsed}s), not waited on"
+else
+    fail "the leg took ${elapsed}s — the probe was waited on, which is #590 all over again"
+fi
+
+if grep -qF 'VERDICT: CERTIFIED' "$out"; then
+    pass "the review still ran after the probe was abandoned"
+else
+    fail "the review never ran — the probe blocked it"
+fi
+
+if grep -qiE 'UNKNOWN|timed out|deadline' "$out"; then
+    pass "the abandoned probe is recorded, not silently omitted"
+else
+    fail "the probe timed out silently — a reviewer cannot tell the build was never checked"
+fi
 
 echo ""
 echo "=== Results ==="


### PR DESCRIPTION
Closes #613.

## The failure this closes

PR #610 ran **eight review rounds with two independent reviewers while CI `validate` was red the entire time.** Both ran the suites directly and correctly reported them green — the failing guard was one nobody was asked about. `scripts/merge-pr.sh` caught it at the merge.

That is "a gate step discovered mid-merge", which #593 Rung 1's stop condition names in so many words. Both reviewers prescribed the same fix independently:

> Seven rounds audited the diff; zero audited the build — that is the whole fix.

Both priority rulings then made this **Rung 1 item 3, ahead of #521**, as closing an observed stop-condition failure rather than discretionary re-planning.

## What it does

The launcher writes a `## CI STATUS` block into the leg's output file **before** exec'ing codex, so the build is stated where the reviewer reads and ahead of the model's own output. The block carries the contract sentence: a certification verdict issued over a build that is not green, or not determinable, is only valid if it says so and says why.

## Preflight, never a gate

A red build is **reported and the leg proceeds.** Deliberate, and the harder half of the design: a leg must stay launchable against known-red CI when that is the point, and a preflight that can refuse to launch is a second way for a review not to happen — the failure #590 exists to prevent. Every probe failure mode (no `gh`, no auth, no network, no PR for the branch) records UNKNOWN and the review runs. The probe gets `< /dev/null` for the same reason the exec line does.

## What the suite caught that review would not have

The first version wrapped the probe in `timeout 30`. **This machine has neither `timeout` nor `gtimeout`** — GNU coreutils, not stock macOS. Every probe would have reported UNKNOWN, forever, silently, on the maintainer's own laptop: this issue's exact failure mode reintroduced by its own fix. Found by a test written RED before the code.

## No new guard

`tests/test-workflow-triggers.sh` already catches the drift that broke #610 and always did. The gap was invocation, not coverage — so this adds no guard, and modifies two existing surfaces (the launcher, its suite). That keeps it inside #593's "no new guard or tooling surface" standing ruling.

## Verification

- `tests/test-run-review-leg.sh` **16/0** (12 → 16 rows), RED first on all four new assertions
- shellcheck clean on both files