### PR TITLE
fix(gate): bind certification to content, not to a SHA (#540)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Run review-leg launcher requirement tests (#590)
         run: ./tests/test-review-leg-launcher-required.sh
 
+      - name: Run clearance-binds-to-tree tests (#540)
+        run: ./tests/test-clearance-binds-to-tree.sh
+
       - name: Run hook stdin boundedness tests (#491 Class 2)
         run: ./tests/test-hook-stdin-bounded.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thank you for your interest in improving the SDLC Harness!
    ./tests/test-stats.sh && ./tests/test-hooks.sh && \
    ./tests/test-codex-gate-command-position.sh && \
    ./tests/test-review-leg-launcher-required.sh && \
+   ./tests/test-clearance-binds-to-tree.sh && \
    ./tests/test-token-spike.sh && \
    ./tests/test-codex-progress-wrapper.sh && \
    ./tests/test-run-review-leg.sh && \
@@ -198,6 +199,7 @@ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
 ./tests/test-hooks.sh
 ./tests/test-codex-gate-command-position.sh
 ./tests/test-review-leg-launcher-required.sh
+./tests/test-clearance-binds-to-tree.sh
 ./tests/test-hook-stdin-bounded.sh
 ./tests/test-token-spike.sh
 ./tests/test-codex-progress-wrapper.sh

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -735,9 +735,14 @@ case "$STATUS" in
         # PreToolUse cannot observe post-command state, so the hook was never
         # able to close this alone, and the base ref is only well-defined at
         # the merge boundary. That makes `scripts/merge-pr.sh` the sole
-        # enforcement point for base_tree — which is exactly why it reads the
-        # base from the PR's baseRefOid and fails closed when it cannot resolve
-        # it, rather than trusting a local tracking ref.
+        # enforcement point for base_tree.
+        #
+        # An earlier version of this sentence said that boundary reads the base
+        # from the PR's `baseRefOid`. It did, and that was the round-2 defect:
+        # `baseRefOid` is the base commit ASSOCIATED WITH THE PR, a snapshot
+        # that does not move when the branch does (measured — PR #615 carried
+        # f8ba12b while main was at d0e1c7b). It now asks the server for the
+        # branch tip directly and fails closed when it cannot.
         exit 0
         ;;
     PENDING_RECHECK)

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -644,23 +644,89 @@ STATUS=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$REVIEW_FILE" \
 
 case "$STATUS" in
     CERTIFIED|REVIEWED)
-        # #437: a CERTIFIED/REVIEWED status string alone doesn't mean the
-        # certification is still current — commits made after it was issued
-        # would otherwise sail through on the same stale status forever.
-        # commit_sha records HEAD at cert time; a mismatch (or a missing
-        # field, e.g. an old-format handoff.json predating this fix) means
-        # new commits landed since certification, so treat it as stale. This
-        # allows exactly one commit after certification (HEAD still equals
-        # the recorded SHA at that commit's PreToolUse check) and blocks the
-        # next one until re-cert. No legacy-compat fallback for missing SHA.
-        COMMIT_SHA=$(grep -o '"commit_sha"[[:space:]]*:[[:space:]]*"[^"]*"' "$REVIEW_FILE" \
+        # #540: staleness keys on the CONTENT certified, never on a SHA.
+        #
+        # THE HOLE THIS REPLACES. The old key was `commit_sha == HEAD`.
+        # PreToolUse runs BEFORE the commit, so at check time HEAD is still
+        # the certified commit and the gate allows — then the commit lands
+        # carrying whatever is in the index, reviewed or not. The resulting
+        # commit was by construction never the one that was reviewed. That is
+        # REVIEW UNIT being unenforceable by the mechanism meant to enforce
+        # it. Found by Sol at file:line; Fable withdrew its own recommendation
+        # to extend this gate once shown the counter-example.
+        #
+        # It also taxed every commit with a re-pin call — ~10 wasted tool
+        # calls in one measured PR cycle — to protect nothing a content pin
+        # does not.
+        #
+        # WHY TREE IDENTITY AND NOT patch-id. An earlier ruling chose
+        # `git patch-id --stable`; both advisors amended it after measuring
+        # two failures. Two diffs differing only in the indentation of an
+        # added Python line produce the IDENTICAL patch-id — it ignores
+        # whitespace by design, and whitespace is semantic in Python, YAML,
+        # Makefiles and string literals. And at the merge boundary the thing
+        # merged is the resulting TREE, not the diff, so a rebase onto moved
+        # upstream keeps patch-id identical while producing content nobody
+        # read. The goal was amended too, not just the primitive:
+        # certification must not automatically survive a changed base.
+        #
+        # WHAT STAYS FREE. Message-only amend, squash and reorder with no
+        # upstream movement all produce the same tree, so certification
+        # survives them at zero cost. Only a change in content invalidates.
+        CANDIDATE_TREE=$(grep -o '"candidate_tree"[[:space:]]*:[[:space:]]*"[^"]*"' "$REVIEW_FILE" \
             | head -1 \
-            | sed 's/.*"commit_sha"[[:space:]]*:[[:space:]]*"//; s/"$//')
-        CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null) || CURRENT_HEAD=""
-        if [ -z "$COMMIT_SHA" ] || [ "$COMMIT_SHA" != "$CURRENT_HEAD" ]; then
-            echo "CROSS-MODEL REVIEW REQUIRED: .reviews/handoff.json certification is stale (commit_sha does not match current HEAD — new commits landed since certification). Re-run Codex cross-model review. $BYPASS_NOTE" >&2
+            | sed 's/.*"candidate_tree"[[:space:]]*:[[:space:]]*"//; s/"$//')
+
+        # Fail closed on an artifact that declares no content, including the
+        # pre-#540 format that carried only commit_sha. Same posture #437 took
+        # for a missing commit_sha and #533 for a missing branch: no
+        # legacy-compat fallback, because a fallback here is the hole reopened
+        # under an older key.
+        if [ -z "$CANDIDATE_TREE" ]; then
+            echo "CROSS-MODEL REVIEW REQUIRED: .reviews/handoff.json is $STATUS but declares no 'candidate_tree'. A certification names the content it was issued over — record it with: git write-tree. $BYPASS_NOTE" >&2
             exit 2
         fi
+
+        # FROZEN INDEX, and this is what makes flag parsing unnecessary.
+        #
+        # `git commit -a` sweeps unstaged tracked changes into the commit, so
+        # with a dirty tracked worktree the committed tree is not the index's
+        # and no pre-commit check of the index can speak for it. The fix is
+        # NOT to look for `-a` on the command line: modelling git's option
+        # grammar in a regex is the #610 trap, where rounds 1-3 scored 3, 6,
+        # 4 — falling, the non-convergence signature — doing exactly that,
+        # and round 4 deleted all of it.
+        #
+        # Requiring a clean tracked worktree dissolves the case instead: with
+        # nothing unstaged, `git commit` and `git commit -a` commit the same
+        # tree, and the index speaks for both. Untracked files are NOT
+        # examined — they are not in the index and `-a` does not add them.
+        if ! git diff --quiet --ignore-submodules -- 2>/dev/null; then
+            echo "CROSS-MODEL REVIEW REQUIRED: tracked files differ between the working tree and the index, so the tree that would be committed is not the one certified (git commit -a would sweep them in). Stage or revert them, then commit. $BYPASS_NOTE" >&2
+            exit 2
+        fi
+
+        # The index IS the candidate: PreToolUse runs before the commit, so
+        # `git write-tree` is exactly the tree the commit is about to carry.
+        # It fails on an unmerged index, and that failure is left to fail
+        # closed — a conflicted tree is not a reviewed tree.
+        INDEX_TREE=$(git write-tree 2>/dev/null) || INDEX_TREE=""
+        if [ -z "$INDEX_TREE" ] || [ "$INDEX_TREE" != "$CANDIDATE_TREE" ]; then
+            echo "CROSS-MODEL REVIEW REQUIRED: the staged content is not what was certified (index tree ${INDEX_TREE:-unreadable}, certified candidate_tree $CANDIDATE_TREE). A certification authorizes the content it was issued over, not the next commit on the branch. Re-run cross-model review on the current content. $BYPASS_NOTE" >&2
+            exit 2
+        fi
+
+        # base_tree is deliberately NOT checked here. At the commit boundary
+        # "the base" is not observable without knowing the commit's kind — it
+        # is HEAD for a normal commit and HEAD^ for an amend — and telling
+        # those apart means reading `--amend` off the command line, which is
+        # the option-grammar trap again. It costs nothing to defer: a rebase
+        # onto moved upstream CHANGES the index tree, so the check above
+        # already refuses it. What base_tree adds is which base the reviewer
+        # read, and `scripts/merge-pr.sh` enforces that at the merge boundary,
+        # where the base ref is well-defined and post-command state is
+        # observable. PreToolUse cannot see post-command state, so the hook
+        # was never able to close this alone.
         exit 0
         ;;
     PENDING_RECHECK)

--- a/hooks/codex-gate-check.sh
+++ b/hooks/codex-gate-check.sh
@@ -720,13 +720,24 @@ case "$STATUS" in
         # "the base" is not observable without knowing the commit's kind — it
         # is HEAD for a normal commit and HEAD^ for an amend — and telling
         # those apart means reading `--amend` off the command line, which is
-        # the option-grammar trap again. It costs nothing to defer: a rebase
-        # onto moved upstream CHANGES the index tree, so the check above
-        # already refuses it. What base_tree adds is which base the reviewer
-        # read, and `scripts/merge-pr.sh` enforces that at the merge boundary,
-        # where the base ref is well-defined and post-command state is
-        # observable. PreToolUse cannot see post-command state, so the hook
-        # was never able to close this alone.
+        # the option-grammar trap again.
+        #
+        # An earlier version of this comment justified the deferral by claiming
+        # a rebase onto moved upstream always CHANGES the index tree, so the
+        # check above already refuses it. Sol falsified that in round 1 of #628
+        # with a running counter-example: when upstream independently produces
+        # the candidate's final content, the rebase drops the now-redundant
+        # branch change and the index tree is unchanged. `base_moved hook=0
+        # candidate_same=yes base_changed=yes`. The claim is false and is not
+        # repeated here.
+        #
+        # The deferral still holds, but for the narrower reason that survives:
+        # PreToolUse cannot observe post-command state, so the hook was never
+        # able to close this alone, and the base ref is only well-defined at
+        # the merge boundary. That makes `scripts/merge-pr.sh` the sole
+        # enforcement point for base_tree — which is exactly why it reads the
+        # base from the PR's baseRefOid and fails closed when it cannot resolve
+        # it, rather than trusting a local tracking ref.
         exit 0
         ;;
     PENDING_RECHECK)

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -454,7 +454,7 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if ! PR_JSON=$(gh pr view "$PR_NUM" --json headRefOid,number,state,baseRefName 2>&1); then
+if ! PR_JSON=$(gh pr view "$PR_NUM" --json headRefOid,number,state,baseRefName,baseRefOid 2>&1); then
     echo "FAILED CLOSED: could not fetch PR #$PR_NUM (gh error): $PR_JSON" >&2
     exit 1
 fi
@@ -469,6 +469,20 @@ fi
 BASE_BRANCH=$(printf '%s' "$PR_JSON" | grep -o '"baseRefName"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"baseRefName"[[:space:]]*:[[:space:]]*"//; s/"$//')
 if [ -z "$BASE_BRANCH" ]; then
     echo "FAILED CLOSED: could not determine the base branch for PR #$PR_NUM" >&2
+    exit 1
+fi
+# WHERE THE BASE ACTUALLY IS, per the server — not per the local tracking ref.
+#
+# Round 1 of #628, found independently by both reviewers and demonstrated with
+# running code rather than argued. The first version read
+# `refs/remotes/origin/$BASE_BRANCH`, which is a cache: absent, the comparison
+# was skipped outright; stale, it still held the certified tree and satisfied
+# the check. Sol advanced a bare server's main and merged a bogus certification
+# at exit 0 with the local ref left behind; Fable reached the same exit 0 by
+# deleting the ref. The check was vacuous in exactly the case it exists for.
+BASE_SHA=$(printf '%s' "$PR_JSON" | grep -o '"baseRefOid"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"baseRefOid"[[:space:]]*:[[:space:]]*"//; s/"$//')
+if [ -z "$BASE_SHA" ]; then
+    echo "FAILED CLOSED: could not determine the base commit (baseRefOid) for PR #$PR_NUM" >&2
     exit 1
 fi
 
@@ -822,9 +836,20 @@ fi
             echo "BLOCKED: $CLEARANCE_FILE declares no 'base_tree'. A certification names the base it was read against, or a rebase onto moved upstream carries it silently (#540). Record it with: git rev-parse \"origin/\$BASE_BRANCH^{tree}\". Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
             exit 1
         fi
-        CUR_BASE_TREE=$(git rev-parse "origin/$BASE_BRANCH^{tree}" 2>/dev/null) || CUR_BASE_TREE=""
-        if [ -n "$CUR_BASE_TREE" ] && [ "$CUR_BASE_TREE" != "$CL_BASE_TREE" ]; then
-            echo "BLOCKED: the base moved since certification — origin/$BASE_BRANCH tree is $CUR_BASE_TREE, certified base_tree is $CL_BASE_TREE. The reviewers read a different base, and the merged result is not what they cleared (#540). Rebase and re-review, or decide it yourself: --user-approved \"<reason>\"." >&2
+        # Resolved from the PR's own baseRefOid with the same fetch-fallback and
+        # the same fail-closed posture as the remote head above. A base we
+        # cannot read is not a base we can clear against.
+        CUR_BASE_TREE=$(git rev-parse "$BASE_SHA^{tree}" 2>/dev/null) || CUR_BASE_TREE=""
+        if [ -z "$CUR_BASE_TREE" ]; then
+            git fetch -q origin "$BASE_SHA" 2>/dev/null || true
+            CUR_BASE_TREE=$(git rev-parse "$BASE_SHA^{tree}" 2>/dev/null) || CUR_BASE_TREE=""
+        fi
+        if [ -z "$CUR_BASE_TREE" ]; then
+            echo "BLOCKED: could not read the tree of the base commit $BASE_SHA ($BASE_BRANCH), so the base the reviewers read cannot be compared against the base this would merge into. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        if [ "$CUR_BASE_TREE" != "$CL_BASE_TREE" ]; then
+            echo "BLOCKED: the base moved since certification — $BASE_BRANCH tree is $CUR_BASE_TREE, certified base_tree is $CL_BASE_TREE. The reviewers read a different base, and the merged result is not what they cleared (#540). Rebase and re-review, or decide it yourself: --user-approved \"<reason>\"." >&2
             exit 1
         fi
         CL_REVIEW_FILE=$(grep -o '"review_file"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"review_file"[[:space:]]*:[[:space:]]*"//; s/"$//')

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -454,13 +454,21 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if ! PR_JSON=$(gh pr view "$PR_NUM" --json headRefOid,number,state 2>&1); then
+if ! PR_JSON=$(gh pr view "$PR_NUM" --json headRefOid,number,state,baseRefName 2>&1); then
     echo "FAILED CLOSED: could not fetch PR #$PR_NUM (gh error): $PR_JSON" >&2
     exit 1
 fi
 HEAD_SHA=$(printf '%s' "$PR_JSON" | grep -o '"headRefOid"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"headRefOid"[[:space:]]*:[[:space:]]*"//; s/"$//')
 if [ -z "$HEAD_SHA" ]; then
     echo "FAILED CLOSED: could not determine remote head SHA for PR #$PR_NUM" >&2
+    exit 1
+fi
+# #540's base_tree check compares against the branch this PR actually targets,
+# never a hardcoded `main`. A PR stacked on another branch has a different base
+# and would otherwise be judged against a base it was never read on.
+BASE_BRANCH=$(printf '%s' "$PR_JSON" | grep -o '"baseRefName"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"baseRefName"[[:space:]]*:[[:space:]]*"//; s/"$//')
+if [ -z "$BASE_BRANCH" ]; then
+    echo "FAILED CLOSED: could not determine the base branch for PR #$PR_NUM" >&2
     exit 1
 fi
 
@@ -754,6 +762,69 @@ fi
         CL_SHA=$(grep -o '"sha"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"sha"[[:space:]]*:[[:space:]]*"//; s/"$//')
         if [ "$CL_SHA" != "$HEAD_SHA" ]; then
             echo "BLOCKED: $CLEARANCE_FILE is stale — its sha ($CL_SHA) does not match the current remote head ($HEAD_SHA). New commits landed since certification. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        # #540, THE MERGE BOUNDARY. The hook cannot close this hole alone:
+        # PreToolUse cannot observe post-command state, so a pre-commit check
+        # can only speak for the index it saw. This is where the object that
+        # actually merges is available, and it is checked against the content
+        # the reviewers read.
+        #
+        # WHY THIS AND NOT THE SHA CHECK ABOVE. The sha check is correct and
+        # stays — it is what keeps CI freshness honest. But a SHA answers "is
+        # this the same commit", and what a review certifies is CONTENT. Those
+        # come apart in both directions: a message-only amend changes the SHA
+        # while changing nothing reviewable (the ~10-wasted-tool-call re-pin
+        # tax), and a rebase onto moved upstream can preserve a diff while
+        # producing a tree nobody read.
+        #
+        # WHY NOT patch-id, which an earlier ruling chose. Measured, then
+        # amended by both advisors: two diffs differing only in the indentation
+        # of an added Python line produce the IDENTICAL patch-id, because
+        # patch-id ignores whitespace by design and whitespace is semantic in
+        # Python, YAML, Makefiles and string literals. And the thing merged
+        # here is the resulting TREE, not the diff.
+        #
+        # base_tree is checked too, and this is the half the hook deliberately
+        # does NOT do. At the commit boundary "the base" is unobservable
+        # without knowing whether the commit is an amend — which means reading
+        # git's option grammar off a command line, the #610 trap. Here the base
+        # ref is well-defined, so the check lands where it is answerable.
+        #
+        # Fails closed on a missing field: an artifact naming no content is the
+        # pre-#540 format, and honouring it would be the hole reopened under an
+        # older key.
+        CL_CAND_TREE=$(grep -o '"candidate_tree"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"candidate_tree"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        if [ -z "$CL_CAND_TREE" ]; then
+            echo "BLOCKED: $CLEARANCE_FILE declares no 'candidate_tree'. A certification names the content it was issued over, not just the commit it happened to sit on (#540). Record it with: git rev-parse 'HEAD^{tree}'. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        REMOTE_TREE=$(git rev-parse "$HEAD_SHA^{tree}" 2>/dev/null) || REMOTE_TREE=""
+        if [ -z "$REMOTE_TREE" ]; then
+            # The object is not local — fetch it rather than guessing. A tree
+            # we cannot read is not a tree we can clear.
+            git fetch -q origin "$HEAD_SHA" 2>/dev/null || true
+            REMOTE_TREE=$(git rev-parse "$HEAD_SHA^{tree}" 2>/dev/null) || REMOTE_TREE=""
+        fi
+        if [ -z "$REMOTE_TREE" ]; then
+            echo "BLOCKED: could not read the tree of the remote head $HEAD_SHA, so the merging content cannot be compared against what was certified. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        if [ "$REMOTE_TREE" != "$CL_CAND_TREE" ]; then
+            echo "BLOCKED: the content about to merge is not the content that was certified — remote head tree $REMOTE_TREE, certified candidate_tree $CL_CAND_TREE (#540). Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        # base_tree pins WHICH BASE the reviewers read. A rebase onto moved
+        # upstream can leave candidate_tree untouched while the integration
+        # result changes, which is the second measurement that killed patch-id.
+        CL_BASE_TREE=$(grep -o '"base_tree"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"base_tree"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        if [ -z "$CL_BASE_TREE" ]; then
+            echo "BLOCKED: $CLEARANCE_FILE declares no 'base_tree'. A certification names the base it was read against, or a rebase onto moved upstream carries it silently (#540). Record it with: git rev-parse \"origin/\$BASE_BRANCH^{tree}\". Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        CUR_BASE_TREE=$(git rev-parse "origin/$BASE_BRANCH^{tree}" 2>/dev/null) || CUR_BASE_TREE=""
+        if [ -n "$CUR_BASE_TREE" ] && [ "$CUR_BASE_TREE" != "$CL_BASE_TREE" ]; then
+            echo "BLOCKED: the base moved since certification — origin/$BASE_BRANCH tree is $CUR_BASE_TREE, certified base_tree is $CL_BASE_TREE. The reviewers read a different base, and the merged result is not what they cleared (#540). Rebase and re-review, or decide it yourself: --user-approved \"<reason>\"." >&2
             exit 1
         fi
         CL_REVIEW_FILE=$(grep -o '"review_file"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"review_file"[[:space:]]*:[[:space:]]*"//; s/"$//')

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -454,7 +454,7 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if ! PR_JSON=$(gh pr view "$PR_NUM" --json headRefOid,number,state,baseRefName,baseRefOid 2>&1); then
+if ! PR_JSON=$(gh pr view "$PR_NUM" --json headRefOid,number,state,baseRefName 2>&1); then
     echo "FAILED CLOSED: could not fetch PR #$PR_NUM (gh error): $PR_JSON" >&2
     exit 1
 fi
@@ -471,18 +471,34 @@ if [ -z "$BASE_BRANCH" ]; then
     echo "FAILED CLOSED: could not determine the base branch for PR #$PR_NUM" >&2
     exit 1
 fi
-# WHERE THE BASE ACTUALLY IS, per the server — not per the local tracking ref.
+# WHERE THE BASE BRANCH IS NOW — asked of the server, every run.
 #
-# Round 1 of #628, found independently by both reviewers and demonstrated with
-# running code rather than argued. The first version read
-# `refs/remotes/origin/$BASE_BRANCH`, which is a cache: absent, the comparison
-# was skipped outright; stale, it still held the certified tree and satisfied
-# the check. Sol advanced a bare server's main and merged a bogus certification
-# at exit 0 with the local ref left behind; Fable reached the same exit 0 by
-# deleting the ref. The check was vacuous in exactly the case it exists for.
-BASE_SHA=$(printf '%s' "$PR_JSON" | grep -o '"baseRefOid"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"baseRefOid"[[:space:]]*:[[:space:]]*"//; s/"$//')
+# Two rounds of #628 got this wrong the SAME way, and the shared mistake is
+# worth more than either fix: both read a CACHED value and treated it as
+# current.
+#
+#   Round 1 read `refs/remotes/origin/$BASE_BRANCH`, a local cache. Absent, the
+#   comparison was skipped outright; stale, it still held the certified tree and
+#   satisfied the check. Both reviewers broke it — one by deleting the ref, one
+#   by advancing a bare server's main and leaving the ref behind.
+#
+#   Round 2 read `baseRefOid` off `gh pr view`, which BOTH reviewers had
+#   prescribed. Live data falsified it: that field is the base commit ASSOCIATED
+#   WITH THE PULL REQUEST, a snapshot that does not move when the branch does.
+#   Measured on this repo — PR #615 carried baseRefOid f8ba12b while main was at
+#   d0e1c7b, different trees. So round 2 replaced an indefinitely stale local
+#   cache with an indefinitely stale server-side snapshot.
+#
+# `baseRefOid` is therefore deliberately NOT in the `pr view --json` list above:
+# a trap field left parsed is a regression waiting to be reintroduced. The ref
+# endpoint below is the branch tip itself.
+if ! BASE_REF_JSON=$(gh api "repos/{owner}/{repo}/git/ref/heads/$BASE_BRANCH" 2>&1); then
+    echo "FAILED CLOSED: could not read the current tip of $BASE_BRANCH (gh error): $BASE_REF_JSON" >&2
+    exit 1
+fi
+BASE_SHA=$(printf '%s' "$BASE_REF_JSON" | grep -o '"sha"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"sha"[[:space:]]*:[[:space:]]*"//; s/"$//')
 if [ -z "$BASE_SHA" ]; then
-    echo "FAILED CLOSED: could not determine the base commit (baseRefOid) for PR #$PR_NUM" >&2
+    echo "FAILED CLOSED: could not determine the current tip of $BASE_BRANCH for PR #$PR_NUM" >&2
     exit 1
 fi
 
@@ -836,9 +852,10 @@ fi
             echo "BLOCKED: $CLEARANCE_FILE declares no 'base_tree'. A certification names the base it was read against, or a rebase onto moved upstream carries it silently (#540). Record it with: git rev-parse \"origin/\$BASE_BRANCH^{tree}\". Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
             exit 1
         fi
-        # Resolved from the PR's own baseRefOid with the same fetch-fallback and
-        # the same fail-closed posture as the remote head above. A base we
-        # cannot read is not a base we can clear against.
+        # $BASE_SHA is the base branch's CURRENT tip, read from the server
+        # above. Resolved here with the same fetch-fallback and the same
+        # fail-closed posture as the remote head. A base we cannot read is not
+        # a base we can clear against.
         CUR_BASE_TREE=$(git rev-parse "$BASE_SHA^{tree}" 2>/dev/null) || CUR_BASE_TREE=""
         if [ -z "$CUR_BASE_TREE" ]; then
             git fetch -q origin "$BASE_SHA" 2>/dev/null || true

--- a/tests/test-clearance-binds-to-tree.sh
+++ b/tests/test-clearance-binds-to-tree.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# A certification must authorize exactly the CONTENT it was issued over (#540).
+#
+# THE HOLE
+#
+# The CERTIFIED lane keys staleness on `commit_sha == HEAD`. PreToolUse runs
+# BEFORE the commit, so at check time HEAD is still the certified commit and
+# the gate allows — then the commit lands with content nobody reviewed. The
+# resulting commit is by construction not the one that was reviewed. Sol found
+# it at file:line during the enforcement-locus reconciliation; Fable withdrew
+# its own recommendation to extend the gate once shown the counter-example.
+#
+# WHY TREE IDENTITY AND NOT patch-id
+#
+# An earlier ruling (2026-08-10) chose `git patch-id --stable`. Both advisors
+# amended it on 2026-08-11 after two measurements:
+#
+#   1. Two diffs differing ONLY in the indentation of an added Python line
+#      produce the IDENTICAL patch-id — it ignores whitespace by design, and
+#      whitespace is semantic in Python, YAML, Makefiles and string literals.
+#      A certification bound by patch-id survives a behavior change.
+#   2. At the merge boundary the thing merged is the resulting TREE, not the
+#      diff. A rebase onto moved upstream keeps patch-id identical while
+#      producing final content nobody reviewed.
+#
+# So the goal was amended, not just the primitive: certification must NOT
+# automatically survive a rebase onto a changed base.
+#
+# WHAT THIS DELIBERATELY KEEPS CHEAP
+#
+# The old SHA key taxed EVERY commit with a re-pin call — measured at ~10
+# wasted tool calls in one PR cycle — and protected nothing a content pin does
+# not. Message-only amend, squash, and reorder with no upstream movement all
+# produce the same tree, so certification survives them at zero cost. Only a
+# change in content invalidates. Rows below pin both directions, because a
+# guard that only ever refuses is indistinguishable from a broken one.
+#
+# WHY THE HOOK DOES NOT PARSE COMMIT FLAGS
+#
+# `git commit <pathspec>` can commit a tree other than the index's. The fix is
+# NOT to inspect flags: modelling git's option grammar in a regex is the #610
+# trap, where rounds 1-3 scored 3, 6, 4 — falling — doing exactly that, and
+# round 4 deleted all of it. Instead the frozen-index precondition dissolves
+# the common case (with no unstaged tracked changes, `git commit` and
+# `git commit -a` commit the same tree as the index), and the pathspec case is
+# caught at the merge boundary in scripts/merge-pr.sh. Pinned as an ACCEPTED
+# LIMIT row, not left implicit.
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HOOK="$REPO_ROOT/hooks/codex-gate-check.sh"
+PASSED=0
+FAILED=0
+
+# Hoisted above every definition: a guard placed after the thing it guards is
+# skipped by any early exit landing between them (#598 round 20).
+if [ -z "${TREE_SUITE_FORCE_FAILURE:-}" ]; then
+    if TREE_SUITE_FORCE_FAILURE=1 "$0" > /dev/null 2>&1; then
+        echo "FATAL: a forced failure still exited 0 — this suite cannot report a regression to CI" >&2
+        exit 1
+    fi
+fi
+
+pass() { PASSED=$((PASSED + 1)); printf '\033[0;32mPASS\033[0m: %s\n' "$1"; }
+fail() { FAILED=$((FAILED + 1)); printf '\033[0;31mFAIL\033[0m: %s\n' "$1"; }
+
+# FAIL CLOSED on a tmpdir we could not create. A fixture that falls back to
+# the caller's cwd runs `git commit` in the REAL repo — that happened, and it
+# corrupted the working tree (#566).
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/sdlc-tree-bind.XXXXXX") || {
+    echo "FATAL: could not create a temp dir; refusing to run in $(pwd)" >&2
+    exit 1
+}
+case "$WORK" in
+    /*) ;;
+    *) echo "FATAL: temp dir '$WORK' is not absolute; refusing to run" >&2; exit 1 ;;
+esac
+trap 'rm -rf "$WORK"' EXIT
+
+# Run the hook against one Bash command, exactly as Claude Code invokes it.
+# Exit 2 is a refusal, 0 an allow. Runs with cwd inside the fixture repo,
+# because the hook reads .reviews/handoff.json relative to cwd.
+run_hook_in() {
+    local dir="$1" cmd="$2"
+    ( cd "$dir" && python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1],"description":"d"}}))' "$cmd" \
+        | "$HOOK" > /dev/null 2>&1; echo $? )
+}
+
+expect_refused() {
+    local desc="$1" dir="$2" cmd="$3" rc
+    rc=$(run_hook_in "$dir" "$cmd")
+    if [ "$rc" = "2" ]; then pass "refused: $desc"; else fail "should have REFUSED (got exit $rc): $desc"; fi
+}
+
+expect_allowed() {
+    local desc="$1" dir="$2" cmd="$3" rc
+    rc=$(run_hook_in "$dir" "$cmd")
+    if [ "$rc" = "0" ]; then pass "allowed: $desc"; else fail "should have ALLOWED (got exit $rc): $desc"; fi
+}
+
+# Build a repo with one baseline commit. Returns nothing; sets REPO.
+new_repo() {
+    REPO="$WORK/$1"
+    mkdir -p "$REPO/.reviews"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@example.com
+    git -C "$REPO" config user.name "SDLC Test"
+    printf 'baseline\n' > "$REPO/file.txt"
+    git -C "$REPO" add file.txt
+    git -C "$REPO" commit -qm baseline
+}
+
+# Write a CERTIFIED handoff. Args: repo, commit_sha, candidate_tree, base_tree.
+# An empty tree arg omits the field entirely, which is how the pre-#540 format
+# is simulated — the fail-closed rows depend on that distinction.
+write_handoff() {
+    local repo="$1" sha="$2" cand="$3" base="$4"
+    {
+        printf '{\n  "status": "CERTIFIED",\n  "branch": "main",\n'
+        printf '  "commit_sha": "%s"' "$sha"
+        [ -n "$cand" ] && printf ',\n  "candidate_tree": "%s"' "$cand"
+        [ -n "$base" ] && printf ',\n  "base_tree": "%s"' "$base"
+        printf '\n}\n'
+    } > "$repo/.reviews/handoff.json"
+}
+
+# ---------------------------------------------------------------------------
+# 1. THE HOLE ITSELF. Certify, then stage content the certification never saw.
+#    Pre-#540 this ALLOWS, because HEAD has not moved yet — that is the bug.
+# ---------------------------------------------------------------------------
+new_repo hole
+HEAD_SHA=$(git -C "$REPO" rev-parse HEAD)
+CERT_TREE=$(git -C "$REPO" rev-parse 'HEAD^{tree}')
+write_handoff "$REPO" "$HEAD_SHA" "$CERT_TREE" "$CERT_TREE"
+printf 'content nobody reviewed\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+expect_refused "staged content differs from the certified candidate_tree" "$REPO" "git commit -m x"
+
+# ---------------------------------------------------------------------------
+# 2. THE PRESERVED CASE. Index matches the certified tree exactly, so the
+#    commit about to be made is the reviewed content. Must ALLOW — this is the
+#    re-pin tax the ruling exists to delete, and a guard that refuses here has
+#    reintroduced it.
+# ---------------------------------------------------------------------------
+new_repo preserved
+printf 'reviewed change\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+CAND=$(git -C "$REPO" write-tree)
+BASE=$(git -C "$REPO" rev-parse 'HEAD^{tree}')
+write_handoff "$REPO" "$(git -C "$REPO" rev-parse HEAD)" "$CAND" "$BASE"
+expect_allowed "index tree equals the certified candidate_tree" "$REPO" "git commit -m x"
+
+# ---------------------------------------------------------------------------
+# 3. THE PATCH-ID KILLER, as a regression test. Two candidates differing ONLY
+#    in the indentation of an added line have the same patch-id and different
+#    behavior. Tree identity must tell them apart.
+# ---------------------------------------------------------------------------
+new_repo whitespace
+printf 'def f(x):\n    if x:\n        return 1\n' > "$REPO/f.py"
+git -C "$REPO" add f.py
+CAND=$(git -C "$REPO" write-tree)
+write_handoff "$REPO" "$(git -C "$REPO" rev-parse HEAD)" "$CAND" "$(git -C "$REPO" rev-parse 'HEAD^{tree}')"
+# Same diff to patch-id; different program.
+printf 'def f(x):\n    if x:\n    return 1\n' > "$REPO/f.py"
+git -C "$REPO" add f.py
+expect_refused "whitespace-only divergence invalidates (patch-id cannot see this)" "$REPO" "git commit -m x"
+
+# ---------------------------------------------------------------------------
+# 4. FROZEN INDEX. Unstaged tracked changes mean the tree that gets committed
+#    is not determinable from the index — `git commit -a` would sweep them in.
+#    This is what makes flag-parsing unnecessary, so it must actually refuse.
+# ---------------------------------------------------------------------------
+new_repo dirty
+printf 'staged\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+CAND=$(git -C "$REPO" write-tree)
+write_handoff "$REPO" "$(git -C "$REPO" rev-parse HEAD)" "$CAND" "$(git -C "$REPO" rev-parse 'HEAD^{tree}')"
+printf 'unstaged on top\n' > "$REPO/file.txt"
+expect_refused "tracked worktree diverges from the index" "$REPO" "git commit -m x"
+
+# ---------------------------------------------------------------------------
+# 5. FAIL CLOSED on the pre-#540 artifact format. A handoff with commit_sha and
+#    no candidate_tree must NOT pass on the old key alone — the same posture
+#    #437 took for a missing commit_sha, and #533 for a missing branch. No
+#    legacy-compat fallback.
+# ---------------------------------------------------------------------------
+new_repo legacy
+write_handoff "$REPO" "$(git -C "$REPO" rev-parse HEAD)" "" ""
+expect_refused "CERTIFIED handoff declaring no candidate_tree" "$REPO" "git commit -m x"
+
+# ---------------------------------------------------------------------------
+# 6. BASE MOVED — and this row is deliberately ALLOWED at the commit boundary.
+#
+#    base_tree exists for the rebase-onto-moved-upstream case: identical diff,
+#    different result, the second measurement that killed patch-id. But it is
+#    enforced at the MERGE boundary, not here, for a reason worth writing down.
+#
+#    At the commit boundary "the base" is not observable without knowing what
+#    kind of commit is being made. For a normal commit the base is HEAD; for an
+#    amend it is HEAD^. Telling those apart means reading `--amend` off the
+#    command line — git option grammar in a regex, the #610 trap. And the
+#    ruling deliberately preserves message-only amend as a zero-cost case, so a
+#    naive `base_tree == HEAD^{tree}` check would refuse exactly the case the
+#    whole change exists to keep cheap.
+#
+#    It costs nothing to defer, because candidate_tree already covers content:
+#    if upstream moved and the branch was rebased, the index tree CHANGES, so
+#    row 1's check refuses it. What base_tree adds is integration-time
+#    knowledge — which base the reviewer actually read — and the merge boundary
+#    is where that is both well-defined and enforceable.
+#
+#    Covered at that boundary by tests/test-merge-gate.sh —
+#    test_wrapper_blocks_moved_base.
+# ---------------------------------------------------------------------------
+new_repo rebased
+printf 'candidate\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+CAND=$(git -C "$REPO" write-tree)
+write_handoff "$REPO" "$(git -C "$REPO" rev-parse HEAD)" "$CAND" "0000000000000000000000000000000000000000"
+expect_allowed "base_tree is a merge-boundary field; content is already pinned by candidate_tree" "$REPO" "git commit -m x"
+
+# ---------------------------------------------------------------------------
+# 7. ACCEPTED LIMIT, pinned so it is a decision and not an oversight.
+#    A pathspec commit can still write a tree other than the index's. The hook
+#    does not parse flags (the #610 trap), so with a frozen index matching the
+#    certification this ALLOWS even though the resulting tree may differ. The
+#    backstop is the merge boundary in scripts/merge-pr.sh, which compares the
+#    REMOTE head tree. If this row ever starts refusing, someone added flag
+#    parsing — read #610 rounds 1-3 before keeping it.
+# ---------------------------------------------------------------------------
+new_repo pathspec
+printf 'a\n' > "$REPO/a.txt"; printf 'b\n' > "$REPO/b.txt"
+git -C "$REPO" add a.txt b.txt
+CAND=$(git -C "$REPO" write-tree)
+write_handoff "$REPO" "$(git -C "$REPO" rev-parse HEAD)" "$CAND" "$(git -C "$REPO" rev-parse 'HEAD^{tree}')"
+expect_allowed "ACCEPTED LIMIT: pathspec commit passes the index check (merge boundary is the backstop)" "$REPO" "git commit -m x -- a.txt"
+
+# ---------------------------------------------------------------------------
+# 8. The gate still only fires on a git commit. A non-commit command with a
+#    stale certification must not be dragged in by the new check.
+# ---------------------------------------------------------------------------
+new_repo unrelated
+write_handoff "$REPO" "deadbeef" "" ""
+expect_allowed "unrelated command with a stale certification" "$REPO" "ls -la"
+
+# Deliberate failure injection for the hoisted self-check above.
+if [ -n "${TREE_SUITE_FORCE_FAILURE:-}" ]; then
+    fail "forced failure (self-check)"
+fi
+
+echo
+echo "=== Results: $PASSED passed, $FAILED failed ==="
+[ "$FAILED" -eq 0 ] || exit 1

--- a/tests/test-cross-model-clearance.sh
+++ b/tests/test-cross-model-clearance.sh
@@ -104,7 +104,7 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
             fi
             exit 0 ;;
     esac
-    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":123,\"state\":\"OPEN\",\"baseRefName\":\"main\"}"
+    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":123,\"state\":\"OPEN\",\"baseRefName\":\"main\",\"baseRefOid\":\"$HEAD_SHA\"}"
     exit 0
 elif [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
     printf '%s\n' "$DIFF_FILES"
@@ -383,7 +383,7 @@ rm -rf "$t"
 t=$(make_stub_env); write_clearance_artifact "$t" "$HEAD_SHA"
 cat > "$t/bin/gh" <<STUB
 #!/bin/bash
-if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -465,7 +465,7 @@ json.dump([{"user": {"login": "m"}, "author_association": "OWNER", "body": hidde
 PY
 cat > "$t/bin/gh" <<STUB
 #!/bin/bash
-if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -575,7 +575,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then
   printf '"%s"\n' '.github/workflows/validate-\360\237\230\200.yml'; exit 0
 elif [ "\$1" = "api" ]; then
@@ -673,7 +673,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -710,7 +710,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) exit 1;; esac        # the query FAILS
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "README.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -749,7 +749,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "README.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -792,7 +792,7 @@ PY
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in

--- a/tests/test-cross-model-clearance.sh
+++ b/tests/test-cross-model-clearance.sh
@@ -104,13 +104,18 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
             fi
             exit 0 ;;
     esac
-    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":123,\"state\":\"OPEN\",\"baseRefName\":\"main\",\"baseRefOid\":\"$HEAD_SHA\"}"
+    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":123,\"state\":\"OPEN\",\"baseRefName\":\"main\"}"
     exit 0
 elif [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
     printf '%s\n' "$DIFF_FILES"
     exit 0
 elif [ "$1" = "api" ]; then
     case "$*" in
+        *git/ref/heads/*)
+            # #540 round 3: the merge boundary asks the server for the base
+            # branch tip. baseRefOid is a PR snapshot and is no longer read.
+            echo "{\"object\":{\"sha\":\"$HEAD_SHA\"}}"
+            exit 0 ;;
         *check-runs*)
             echo "{\"conclusion\":\"$VALIDATE_CONCLUSION\",\"name\":\"validate\"}"
             ;;
@@ -383,10 +388,11 @@ rm -rf "$t"
 t=$(make_stub_env); write_clearance_artifact "$t" "$HEAD_SHA"
 cat > "$t/bin/gh" <<STUB
 #!/bin/bash
-if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
+    *git/ref/heads/*) echo '{"object":{"sha":"$HEAD_SHA"}}'; exit 0;;
     *check-runs*) echo '{"conclusion":"success","name":"validate"}';;
     *issues*comments*) printf '[{"user":{"login":"x"},"body":"<!-- CROSS-MODEL-CLEARANCE --> {\\\\"reviewer\\\\":\\\\"codex\\\\"} prose {\\\\"confidence\\\\":100} prose {\\\\"sha\\\\":\\\\"$HEAD_SHA\\\\"}"},{"user":{"login":"x"},"body":"<!-- CROSS-MODEL-CLEARANCE --> {\\\\"reviewer\\\\":\\\\"fable\\\\"} prose {\\\\"confidence\\\\":100} prose {\\\\"sha\\\\":\\\\"$HEAD_SHA\\\\"}"}]\n';;
     *pulls*files*) : ;;
@@ -465,10 +471,11 @@ json.dump([{"user": {"login": "m"}, "author_association": "OWNER", "body": hidde
 PY
 cat > "$t/bin/gh" <<STUB
 #!/bin/bash
-if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
+    *git/ref/heads/*) echo '{"object":{"sha":"$HEAD_SHA"}}'; exit 0;;
     *check-runs*) echo '{"conclusion":"success","name":"validate"}';;
     *issues*comments*) cat "$t/comments.json";;
     *pulls*files*) : ;;
@@ -575,11 +582,12 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then
   printf '"%s"\n' '.github/workflows/validate-\360\237\230\200.yml'; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
+    *git/ref/heads/*) echo '{"object":{"sha":"$HEAD_SHA"}}'; exit 0;;
     *check-runs*) echo '{"conclusion":"success","name":"validate"}';;
     *issues*comments*) printf '[]\n';;
     *pulls*files*) printf '[{"filename":".github/workflows/validate-\\ud83d\\ude00.yml","status":"added"}]\n';;
@@ -673,10 +681,11 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
+    *git/ref/heads/*) echo '{"object":{"sha":"$HEAD_SHA"}}'; exit 0;;
     *check-runs*) echo '{"conclusion":"success","name":"validate"}';;
     *issues*comments*) cat "$t/comments.json";;
     *pulls*files*) echo '[{"filename":"CLAUDE_CODE_SDLC_WIZARD.md","status":"modified"}]';;
@@ -710,10 +719,11 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) exit 1;; esac        # the query FAILS
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "README.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
+    *git/ref/heads/*) echo '{"object":{"sha":"$HEAD_SHA"}}'; exit 0;;
     *check-runs*) echo '{"conclusion":"success","name":"validate"}';;
     *issues*comments*) printf '[]\n';;
     *pulls*files*) printf '[{"filename":"README.md","status":"modified"}]\n';;
@@ -749,10 +759,11 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "README.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
+    *git/ref/heads/*) echo '{"object":{"sha":"$HEAD_SHA"}}'; exit 0;;
     *check-runs*) echo '{"conclusion":"success","name":"validate"}';;
     *issues*comments*) printf '[]\n';;
     *pulls*files*) cat "$t/files.json";;
@@ -792,10 +803,11 @@ PY
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main","baseRefOid":"$HEAD_SHA"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
+    *git/ref/heads/*) echo '{"object":{"sha":"$HEAD_SHA"}}'; exit 0;;
     *check-runs*) echo '{"conclusion":"success","name":"validate"}';;
     *issues*comments*) cat "$1/comments.json";;
     *pulls*files*) echo '[{"filename":"CLAUDE_CODE_SDLC_WIZARD.md","status":"modified"}]';;

--- a/tests/test-cross-model-clearance.sh
+++ b/tests/test-cross-model-clearance.sh
@@ -54,7 +54,20 @@ FAIL=0
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
-HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+# #540: the merge boundary resolves the head's TREE, so the fixture head can no
+# longer be a made-up 40-char string — git has to be able to look it up. One
+# template repo is built here and its .git is copied into every fixture, which
+# keeps HEAD_SHA a single file-scope constant (dozens of call sites embed it in
+# clearance-comment payloads) while making it a real object.
+XMC_TEMPLATE=$(mktemp -d "${TMPDIR:-/tmp}/xmc-tpl.XXXXXX") || exit 1
+trap 'rm -rf "$XMC_TEMPLATE"' EXIT
+git -C "$XMC_TEMPLATE" init -q
+git -C "$XMC_TEMPLATE" config user.email t@example.com
+git -C "$XMC_TEMPLATE" config user.name "SDLC Test"
+git -C "$XMC_TEMPLATE" commit -q --allow-empty -m fixture
+git -C "$XMC_TEMPLATE" update-ref refs/remotes/origin/main HEAD
+HEAD_SHA=$(git -C "$XMC_TEMPLATE" rev-parse HEAD)
+HEAD_TREE=$(git -C "$XMC_TEMPLATE" rev-parse 'HEAD^{tree}')
 OTHER_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 # ---------------------------------------------------------------------------
@@ -71,6 +84,8 @@ make_stub_env() {
     local tmpdir
     tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/xmc.XXXXXX") || return 1
     mkdir -p "$tmpdir/bin" "$tmpdir/.reviews"
+    # A real repo whose HEAD is HEAD_SHA, so the #540 tree lookups resolve.
+    cp -R "$XMC_TEMPLATE/.git" "$tmpdir/.git"
     cat > "$tmpdir/bin/gh" <<'STUB'
 #!/bin/bash
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
@@ -89,7 +104,7 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
             fi
             exit 0 ;;
     esac
-    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":123,\"state\":\"OPEN\"}"
+    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":123,\"state\":\"OPEN\",\"baseRefName\":\"main\"}"
     exit 0
 elif [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
     printf '%s\n' "$DIFF_FILES"
@@ -163,6 +178,7 @@ STUB
 write_clearance_artifact() {
     cat > "$1/.reviews/merge-clearance-123.json" <<JSON
 { "pr_number": 123, "status": "CERTIFIED", "round": 4, "sha": "$2",
+  "candidate_tree": "${3:-$HEAD_TREE}", "base_tree": "${4:-$HEAD_TREE}",
   "review_file": ".reviews/r.md" }
 JSON
     echo "review body" > "$1/.reviews/r.md"
@@ -367,7 +383,7 @@ rm -rf "$t"
 t=$(make_stub_env); write_clearance_artifact "$t" "$HEAD_SHA"
 cat > "$t/bin/gh" <<STUB
 #!/bin/bash
-if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN"}'; exit 0
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -449,7 +465,7 @@ json.dump([{"user": {"login": "m"}, "author_association": "OWNER", "body": hidde
 PY
 cat > "$t/bin/gh" <<STUB
 #!/bin/bash
-if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN"}'; exit 0
+if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -559,7 +575,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then
   printf '"%s"\n' '.github/workflows/validate-\360\237\230\200.yml'; exit 0
 elif [ "\$1" = "api" ]; then
@@ -657,7 +673,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -694,7 +710,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) exit 1;; esac        # the query FAILS
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "README.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -733,7 +749,7 @@ cat > "$t/bin/gh" <<STUB
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "README.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in
@@ -776,7 +792,7 @@ PY
 #!/bin/bash
 if [ "\$1" = "pr" ] && [ "\$2" = "view" ]; then
   case "\$*" in *changedFiles*) echo 1; exit 0;; esac
-  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN"}'; exit 0
+  echo '{"headRefOid":"$HEAD_SHA","number":123,"state":"OPEN","baseRefName":"main"}'; exit 0
 elif [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then echo "CLAUDE_CODE_SDLC_WIZARD.md"; exit 0
 elif [ "\$1" = "api" ]; then
   case "\$*" in

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -3768,12 +3768,15 @@ test_codex_gate_blocks_commit_without_review() {
 }
 
 test_codex_gate_allows_commit_with_certified_review() {
-    local tmpdir head_sha
+    local tmpdir head_sha idx_tree
     tmpdir=$(mktemp -d)
     (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init) > /dev/null 2>&1
     head_sha=$(cd "$tmpdir" && git rev-parse HEAD)
     mkdir -p "$tmpdir/.reviews"
-    printf '{"status":"CERTIFIED","score":9,"commit_sha":"%s"}' "$head_sha" > "$tmpdir/.reviews/handoff.json"
+    # #540: a certification names the CONTENT it was issued over. The
+    # index is the candidate here — PreToolUse runs before the commit.
+    idx_tree=$(cd "$tmpdir" && git write-tree)
+    printf '{"status":"CERTIFIED","score":9,"commit_sha":"%s","candidate_tree":"%s"}' "$head_sha" "$idx_tree" > "$tmpdir/.reviews/handoff.json"
     local out exit_code
     out=$(printf '%s' '{"tool_input":{"command":"git commit -m \"fix: something\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1)
     exit_code=$?
@@ -3786,12 +3789,15 @@ test_codex_gate_allows_commit_with_certified_review() {
 }
 
 test_codex_gate_allows_commit_with_reviewed_status() {
-    local tmpdir head_sha
+    local tmpdir head_sha idx_tree
     tmpdir=$(mktemp -d)
     (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init) > /dev/null 2>&1
     head_sha=$(cd "$tmpdir" && git rev-parse HEAD)
     mkdir -p "$tmpdir/.reviews"
-    printf '{"status":"REVIEWED","commit_sha":"%s"}' "$head_sha" > "$tmpdir/.reviews/handoff.json"
+    # #540: a certification names the CONTENT it was issued over. The
+    # index is the candidate here — PreToolUse runs before the commit.
+    idx_tree=$(cd "$tmpdir" && git write-tree)
+    printf '{"status":"REVIEWED","commit_sha":"%s","candidate_tree":"%s"}' "$head_sha" "$idx_tree" > "$tmpdir/.reviews/handoff.json"
     local out exit_code
     out=$(printf '%s' '{"tool_input":{"command":"git commit -m \"fix: something\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1)
     exit_code=$?
@@ -3803,38 +3809,48 @@ test_codex_gate_allows_commit_with_reviewed_status() {
     fi
 }
 
-# ROADMAP #437: a CERTIFIED/REVIEWED handoff.json has no freshness check — any
-# number of new commits can land after certification and still sail through
-# the gate on the same stale status string. Proven live in the v1.84.0
-# release: 2 real post-certification commits both passed the gate on a
-# round-11 CERTIFIED handoff that never got re-issued. Fix: certification
-# records commit_sha (HEAD at cert time); the gate compares it to current
-# HEAD and treats a mismatch as stale. This allows exactly one commit after
-# certification (HEAD still equals the recorded SHA at that commit's
-# PreToolUse check) and blocks the next one until re-cert.
-test_codex_gate_blocks_stale_certification_after_new_commit() {
-    local tmpdir cert_sha
+# ROADMAP #437 originally: a CERTIFIED handoff had no freshness check at all,
+# proven live in the v1.84.0 release when 2 post-certification commits both
+# sailed through on a round-11 CERTIFIED handoff. #437's answer was
+# commit_sha == HEAD.
+#
+# #540 REPLACED THAT KEY, and this row was rewritten with it. The SHA key had
+# the hole it was meant to close still in it: PreToolUse runs BEFORE the
+# commit, so HEAD still equals the certified SHA at check time and the gate
+# allowed a commit carrying content nobody reviewed. It also invalidated on
+# every SHA change — including message-only amends that change nothing
+# reviewable — costing a re-pin call per commit.
+#
+# So what must be refused is CONTENT that moved, not a SHA that moved. This
+# row now proves exactly that, and the paired allow rows above prove the
+# other direction.
+test_codex_gate_blocks_certification_when_content_moved() {
+    local tmpdir cert_sha cert_tree
     tmpdir=$(mktemp -d)
     (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init) > /dev/null 2>&1
     cert_sha=$(cd "$tmpdir" && git rev-parse HEAD)
+    cert_tree=$(cd "$tmpdir" && git write-tree)
     mkdir -p "$tmpdir/.reviews"
-    printf '{"status":"CERTIFIED","commit_sha":"%s"}' "$cert_sha" > "$tmpdir/.reviews/handoff.json"
-    # A commit lands after certification (simulates the real v1.84.0 incident:
-    # a post-certification CI-shepherd fix committed without re-review).
-    (cd "$tmpdir" && git commit -q --allow-empty -m "post-cert fix") > /dev/null 2>&1
+    printf '{"status":"CERTIFIED","commit_sha":"%s","candidate_tree":"%s"}' "$cert_sha" "$cert_tree" > "$tmpdir/.reviews/handoff.json"
+    # Content the certification never saw is staged. Under the old SHA key this
+    # ALLOWED, because HEAD had not moved yet — the hole #540 exists to close.
+    printf 'unreviewed\n' > "$tmpdir/new.txt"
+    (cd "$tmpdir" && git add new.txt) > /dev/null 2>&1
     local out exit_code
     out=$(printf '%s' '{"tool_input":{"command":"git commit -m \"another fix\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
-    if [ "$exit_code" -eq 2 ] && echo "$out" | grep -qi "stale"; then
-        pass "codex gate BLOCKS (exit 2) a stale certification after a new commit landed"
+    if [ "$exit_code" -eq 2 ] && echo "$out" | grep -qi "not what was certified"; then
+        pass "codex gate BLOCKS (exit 2) staged content the certification never saw"
     else
-        fail "codex gate should exit 2 + mention staleness once HEAD has moved past the certified commit_sha, got exit=$exit_code out: $out"
+        fail "codex gate should exit 2 when the index tree is not the certified candidate_tree, got exit=$exit_code out: $out"
     fi
 }
 
-# Missing commit_sha (an old-format handoff.json from before this fix) is
-# treated as stale, not silently allowed — no legacy-compat fallback.
-test_codex_gate_blocks_missing_commit_sha_as_stale() {
+# An old-format handoff.json — one naming no candidate_tree, which is every
+# handoff written before #540 — fails closed. Same posture #437 took for a
+# missing commit_sha and #533 for a missing branch: honouring the older key
+# would be the hole reopened under it.
+test_codex_gate_blocks_missing_candidate_tree() {
     local tmpdir
     tmpdir=$(mktemp -d)
     (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init) > /dev/null 2>&1
@@ -3843,10 +3859,10 @@ test_codex_gate_blocks_missing_commit_sha_as_stale() {
     local out exit_code
     out=$(printf '%s' '{"tool_input":{"command":"git commit -m \"fix: something\""}}' | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
-    if [ "$exit_code" -eq 2 ] && echo "$out" | grep -qi "stale"; then
-        pass "codex gate BLOCKS (exit 2) an old-format handoff.json with no commit_sha"
+    if [ "$exit_code" -eq 2 ] && echo "$out" | grep -q "declares no 'candidate_tree'"; then
+        pass "codex gate BLOCKS (exit 2) an old-format handoff.json naming no content"
     else
-        fail "codex gate should exit 2 + mention staleness when commit_sha is missing, got exit=$exit_code out: $out"
+        fail "codex gate should exit 2 + name candidate_tree when it is missing, got exit=$exit_code out: $out"
     fi
 }
 
@@ -4253,7 +4269,7 @@ test_codex_gate_silent_on_shapes_that_do_not_invoke_git() {
 # with a CERTIFIED handoff matching HEAD, the same four shapes must still pass
 # through silently.
 test_codex_gate_allows_certified_commit_split_across_lines() {
-    local tmpdir head_sha out exit_code failures label cmd
+    local tmpdir head_sha idx_tree out exit_code failures label cmd
     failures=""
     for label in 'newline-separated:cd foo\ngit commit -m \"x\"' \
                  'line-continuation:git \\\n  commit -m \"x\"' \
@@ -4263,8 +4279,10 @@ test_codex_gate_allows_certified_commit_split_across_lines() {
         tmpdir=$(mktemp -d)
         (cd "$tmpdir" && git init -q && git commit -q --allow-empty -m init) > /dev/null 2>&1
         head_sha=$(cd "$tmpdir" && git rev-parse HEAD)
+        idx_tree=$(cd "$tmpdir" && git write-tree)
         mkdir -p "$tmpdir/.reviews"
-        printf '{"status":"CERTIFIED","score":9,"commit_sha":"%s"}' "$head_sha" > "$tmpdir/.reviews/handoff.json"
+        # #540: certification names content, so the artifact carries the tree.
+        printf '{"status":"CERTIFIED","score":9,"commit_sha":"%s","candidate_tree":"%s"}' "$head_sha" "$idx_tree" > "$tmpdir/.reviews/handoff.json"
         out=$(printf '{"tool_input":{"command":"%s"}}' "$cmd" | (cd "$tmpdir" && "$HOOKS_DIR/codex-gate-check.sh") 2>&1) && exit_code=0 || exit_code=$?
         rm -rf "$tmpdir"
         { [ "$exit_code" -eq 0 ] && [ -z "$out" ]; } || failures="$failures [${label%%:*} -> exit=$exit_code]"
@@ -4463,8 +4481,8 @@ test_codex_gate_blocks_commit_with_dash_c_config_flag
 test_codex_gate_blocks_commit_with_quote_before_git_commit
 test_codex_gate_silent_when_only_description_mentions_commit
 test_codex_gate_blocks_commit_with_quoted_value_containing_space
-test_codex_gate_blocks_stale_certification_after_new_commit
-test_codex_gate_blocks_missing_commit_sha_as_stale
+test_codex_gate_blocks_certification_when_content_moved
+test_codex_gate_blocks_missing_candidate_tree
 test_codex_gate_allows_in_flight_commit_on_declared_branch
 test_codex_gate_blocks_in_flight_commit_on_branch_mismatch
 test_codex_gate_blocks_in_flight_commit_with_no_branch_field

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -311,6 +311,23 @@ setup_wrapper_fixture() {
     mkdir -p "$tmpdir/bin" "$tmpdir/.reviews" "$tmpdir/tests"
     git init -q "$tmpdir"
 
+    # #540: the merge boundary compares the REMOTE HEAD's TREE against the
+    # certified candidate_tree, so the fixture's head can no longer be a
+    # made-up string like "abc123" — it has to be an object git can resolve.
+    # The fixture therefore makes one real commit and publishes it as both the
+    # PR head and origin/<base>. Tests that want a STALE sha still pass a
+    # literal; only the "current head" ones read .fixture-sha.
+    git -C "$tmpdir" config user.email t@example.com
+    git -C "$tmpdir" config user.name "SDLC Test"
+    printf 'fixture\n' > "$tmpdir/tests/keep.txt"
+    git -C "$tmpdir" add tests/keep.txt
+    git -C "$tmpdir" commit -qm fixture
+    git -C "$tmpdir" rev-parse HEAD > "$tmpdir/.fixture-sha"
+    git -C "$tmpdir" rev-parse 'HEAD^{tree}' > "$tmpdir/.fixture-tree"
+    # origin/main must exist: base_tree is compared against the branch the PR
+    # actually targets, read from the PR itself rather than assumed.
+    git -C "$tmpdir" update-ref refs/remotes/origin/main HEAD
+
     # Control file the stub gh reads: one KEY=VALUE per line.
     # HEAD_SHA, VALIDATE_CONCLUSION, DIFF_FILES (newline-separated, base64
     # would be overkill — use a sentinel-delimited list), DELETED_TEST_FILES,
@@ -326,7 +343,8 @@ setup_wrapper_fixture() {
     # pulls/files endpoint — NOT via `gh pr diff`, which has no per-path
     # filter flag.
     cat > "$tmpdir/.gh-stub-config" <<'CONFIG'
-HEAD_SHA=abc123
+HEAD_SHA=__FIXTURE_SHA__
+BASE_REF=main
 VALIDATE_CONCLUSION=success
 EXTRA_VALIDATE_CONCLUSION=
 DIFF_FILES=src/foo.js
@@ -336,6 +354,10 @@ PACKAGE_JSON_VERSION_CHANGED=
 BEYOND_FIRST_PAGE=
 CLEARANCE_PAYLOADS=
 CONFIG
+    # Splice the real sha in after the heredoc, which is quoted so it cannot
+    # expand.
+    sed -i.bak "s/__FIXTURE_SHA__/$(cat "$tmpdir/.fixture-sha")/" "$tmpdir/.gh-stub-config"
+    rm -f "$tmpdir/.gh-stub-config.bak"
 
     cat > "$tmpdir/bin/gh" <<'STUB'
 #!/bin/bash
@@ -354,7 +376,7 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
             [ "$n" -eq 0 ] && n=1
             echo "$n"; exit 0 ;;
     esac
-    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":${PR_NUM:-123},\"state\":\"OPEN\"}"
+    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":${PR_NUM:-123},\"state\":\"OPEN\",\"baseRefName\":\"${BASE_REF:-main}\"}"
     exit 0
 elif [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
     printf '%s\n' "$DIFF_FILES"
@@ -405,6 +427,10 @@ elif [ "$1" = "api" ]; then
                 # unicode-escape test silently tested nothing. GitHub's API
                 # returns a real comment's backslash as \\, which is what this
                 # now reproduces.
+                # __FIXTURE_SHA__ resolves here rather than in the config,
+                # because #540 made the fixture head a real git object and a
+                # test cannot know its value at authoring time.
+                payload=${payload//__FIXTURE_SHA__/$HEAD_SHA}
                 printf '{"user":{"login":"maintainer"},"author_association":"OWNER","body":"**CROSS-MODEL-CLEARANCE**\\n\\n```json\\n%s\\n```"}' \
                     "$(printf '%s' "$payload" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
             done <<< "${CLEARANCE_PAYLOADS:-}"
@@ -473,12 +499,20 @@ STUB
 
 write_clearance() {
     local tmpdir="$1" pr="$2" status="$3" round="$4" sha="$5" review_file="$6"
+    # #540: a clearance names the CONTENT it was issued over, not just the
+    # commit it sat on. Both default to the fixture's real trees so existing
+    # rows keep testing what they were written to test; pass 7/8 to certify
+    # content that is deliberately wrong.
+    local cand="${7:-$(cat "$tmpdir/.fixture-tree")}"
+    local base="${8:-$(cat "$tmpdir/.fixture-tree")}"
     cat > "$tmpdir/.reviews/merge-clearance-$pr.json" <<JSON
 {
   "pr_number": $pr,
   "status": "$status",
   "round": $round,
   "sha": "$sha",
+  "candidate_tree": "$cand",
+  "base_tree": "$base",
   "review_file": "$review_file"
 }
 JSON
@@ -588,7 +622,7 @@ test_wrapper_blocks_missing_clearance() {
 test_wrapper_blocks_non_certified_status() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
-    write_clearance "$tmpdir" 123 "PENDING_REVIEW" 1 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "PENDING_REVIEW" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -603,7 +637,7 @@ test_wrapper_blocks_non_certified_status() {
 test_wrapper_blocks_round_1_only() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
-    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -611,6 +645,74 @@ test_wrapper_blocks_round_1_only() {
         pass "wrapper blocks a round-1-only CERTIFIED as insufficient dialogue"
     else
         fail "wrapper should block round=1 CERTIFIED, got exit=$exit_code out=$out"
+    fi
+}
+
+# --- #540: the clearance names CONTENT, and the merge boundary checks it ---
+#
+# The hook can only speak for the index it saw before the commit; PreToolUse
+# cannot observe post-command state. This is the other half, and the half that
+# sees the object that actually merges.
+
+# Test: certified content is not the content that would merge
+test_wrapper_blocks_wrong_candidate_tree() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # A well-formed clearance, current SHA, round 2 — everything the pre-#540
+    # gate asked for — but naming a tree that is not the one on the head.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "4b825dc642cb6eb9a060e54bf8d69288fbee4904" "$(cat "$tmpdir/.fixture-tree")"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && echo "$out" | grep -q "not the content that was certified"; then
+        pass "wrapper blocks when the merging tree is not the certified candidate_tree"
+    else
+        fail "wrapper should block on candidate_tree mismatch, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: the base moved under the certification. Same candidate_tree, different
+# base — a rebase onto moved upstream leaves the diff alone and changes the
+# result, which is the measurement that killed patch-id as the primitive.
+test_wrapper_blocks_moved_base() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "$(cat "$tmpdir/.fixture-tree")" "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && echo "$out" | grep -q "the base moved since certification"; then
+        pass "wrapper blocks when the certified base_tree is not the current base"
+    else
+        fail "wrapper should block on base_tree mismatch, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: the pre-#540 artifact format fails closed. A clearance carrying only a
+# sha named no content, and honouring it would be the hole reopened under an
+# older key — the same posture #437 took for a missing commit_sha.
+test_wrapper_blocks_clearance_without_trees() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Hand-written in the OLD shape: no candidate_tree, no base_tree.
+    cat > "$tmpdir/.reviews/merge-clearance-123.json" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && echo "$out" | grep -q "declares no 'candidate_tree'"; then
+        pass "wrapper fails closed on a pre-#540 clearance that names no content"
+    else
+        fail "wrapper should block a clearance with no candidate_tree, got exit=$exit_code out=$out"
     fi
 }
 
@@ -633,7 +735,7 @@ test_wrapper_blocks_stale_clearance() {
 test_wrapper_blocks_empty_review_artifact() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/missing-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/missing-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
     if [ "$exit_code" -ne 0 ] && echo "$out" | grep -qi "review"; then
@@ -648,7 +750,7 @@ test_wrapper_blocks_denylisted_workflow_touch() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
     sed -i.bak 's#DIFF_FILES=src/foo.js#DIFF_FILES=.github/workflows/ci.yml#' "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -666,7 +768,7 @@ test_wrapper_blocks_self_referential_touch() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
     sed -i.bak 's#DIFF_FILES=src/foo.js#DIFF_FILES=scripts/merge-pr.sh#' "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -682,7 +784,7 @@ test_wrapper_blocks_test_deletion() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
     sed -i.bak 's#DELETED_TEST_FILES=#DELETED_TEST_FILES=tests/test-foo.sh#' "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -701,7 +803,7 @@ test_wrapper_blocks_test_file_renamed_out_of_tests_dir() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
     sed -i.bak "s#RENAMED_TEST_FILES=#RENAMED_TEST_FILES='tests/test-foo.sh->archive/test-foo.sh'#" "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -720,7 +822,7 @@ test_wrapper_blocks_test_deletion_beyond_first_page() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
     sed -i.bak 's#BEYOND_FIRST_PAGE=#BEYOND_FIRST_PAGE=tests/test-late-page.sh#' "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -741,7 +843,7 @@ test_wrapper_blocks_package_json_version_change() {
     tmpdir=$(setup_wrapper_fixture)
     sed -i.bak -e 's#DIFF_FILES=src/foo.js#DIFF_FILES=package.json#' \
         -e 's#PACKAGE_JSON_VERSION_CHANGED=#PACKAGE_JSON_VERSION_CHANGED=1#' "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -759,7 +861,7 @@ test_wrapper_blocks_wizard_doc_touch() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
     sed -i.bak 's#DIFF_FILES=src/foo.js#DIFF_FILES=CLAUDE_CODE_SDLC_WIZARD.md#' "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -774,14 +876,14 @@ test_wrapper_blocks_wizard_doc_touch() {
 test_wrapper_merges_when_all_conditions_met() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
-    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED: pr merge 123 --squash --match-head-commit abc123"; then
+    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED: pr merge 123 --squash --match-head-commit $(cat "$tmpdir/.fixture-sha")"; then
         pass "wrapper merges with the exact expected command when all conditions are met"
     else
-        fail "wrapper should invoke 'gh pr merge 123 --squash --match-head-commit abc123', got exit=$exit_code out=$out"
+        fail "wrapper should invoke 'gh pr merge 123 --squash --match-head-commit <fixture sha>', got exit=$exit_code out=$out"
     fi
 }
 
@@ -832,6 +934,9 @@ test_wrapper_blocks_missing_clearance
 test_wrapper_blocks_non_certified_status
 test_wrapper_blocks_round_1_only
 test_wrapper_blocks_stale_clearance
+test_wrapper_blocks_wrong_candidate_tree
+test_wrapper_blocks_moved_base
+test_wrapper_blocks_clearance_without_trees
 test_wrapper_blocks_empty_review_artifact
 test_wrapper_blocks_denylisted_workflow_touch
 test_wrapper_blocks_self_referential_touch
@@ -862,7 +967,7 @@ run_with_clearance() {
     tmpdir=$(setup_wrapper_fixture)
     printf 'DIFF_FILES=CLAUDE_CODE_SDLC_WIZARD.md\n' >> "$tmpdir/.gh-stub-config"
     printf 'CLEARANCE_PAYLOADS=%s\n' "$(printf '%q' "$payloads")" >> "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "review body" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 --cross-model-cleared 2>&1) && code=0 || code=$?
     rm -rf "$tmpdir"
@@ -888,16 +993,16 @@ refute_merge() {  # $1=result  $2=what was being attempted
 test_clearance_requires_verdict_field() {
     # Two reviewers, both >=95, both bound to the head SHA, NEITHER declaring a
     # verdict. Confidence alone must not clear a merge.
-    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","confidence":97,"sha":"abc123"}
-{"reviewer":"fable-5","confidence":96,"sha":"abc123"}')" \
+    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","confidence":97,"sha":"__FIXTURE_SHA__"}
+{"reviewer":"fable-5","confidence":96,"sha":"__FIXTURE_SHA__"}')" \
         "clearance with no verdict field does not merge"
 }
 
 test_clearance_rejects_negative_verdict() {
     # THE DEFECT, stated as a test: a reviewer who says NO, at high confidence,
     # must never clear. Before the fix this merged.
-    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"NO","confidence":97,"sha":"abc123"}
-{"reviewer":"fable-5","verdict":"NO","confidence":99,"sha":"abc123"}')" \
+    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"NO","confidence":97,"sha":"__FIXTURE_SHA__"}
+{"reviewer":"fable-5","verdict":"NO","confidence":99,"sha":"__FIXTURE_SHA__"}')" \
         "two confident NO verdicts do not merge"
 }
 
@@ -906,8 +1011,8 @@ test_clearance_rejects_lowercase_verdict() {
     # YES, so the exact-match check I had documented as strict was not strict.
     # A verdict is a machine-written field in a machine-written payload; a
     # reviewer that cannot emit the exact token has not cleared anything.
-    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"yes","confidence":97,"sha":"abc123"}
-{"reviewer":"fable-5","verdict":"YeS","confidence":96,"sha":"abc123"}')" \
+    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"yes","confidence":97,"sha":"__FIXTURE_SHA__"}
+{"reviewer":"fable-5","verdict":"YeS","confidence":96,"sha":"__FIXTURE_SHA__"}')" \
         "case-variant verdicts (yes / YeS) do not merge"
 }
 
@@ -915,8 +1020,8 @@ test_clearance_rejects_duplicate_verdict_keys() {
     # Codex: a payload carrying `verdict` TWICE — NO first, YES last — merged,
     # because JSON parsers keep the last duplicate key. The rendered comment can
     # be made to read as a refusal while the parsed object says YES.
-    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"NO","confidence":97,"sha":"abc123","verdict":"YES"}
-{"reviewer":"fable-5","verdict":"NO","confidence":96,"sha":"abc123","verdict":"YES"}')" \
+    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"NO","confidence":97,"sha":"__FIXTURE_SHA__","verdict":"YES"}
+{"reviewer":"fable-5","verdict":"NO","confidence":96,"sha":"__FIXTURE_SHA__","verdict":"YES"}')" \
         "a duplicated verdict key (NO then YES) does not merge"
 }
 
@@ -926,8 +1031,8 @@ test_clearance_rejects_unicode_escaped_duplicate_key() {
     # did — and kept the last one, YES. Counting literal text cannot win against
     # escaping, which is why the fix stopped counting text and instead pins the
     # payload to an exact key set with no escapes permitted anywhere.
-    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"NO","confidence":97,"sha":"abc123","\u0076erdict":"YES"}
-{"reviewer":"fable-5","verdict":"NO","confidence":96,"sha":"abc123","ver\u0064ict":"YES"}')" \
+    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"NO","confidence":97,"sha":"__FIXTURE_SHA__","\u0076erdict":"YES"}
+{"reviewer":"fable-5","verdict":"NO","confidence":96,"sha":"__FIXTURE_SHA__","ver\u0064ict":"YES"}')" \
         "unicode-escaped duplicate keys do not merge"
 }
 
@@ -935,8 +1040,8 @@ test_clearance_rejects_unknown_extra_key() {
     # Consequence of the positive anchor: the payload carries exactly the four
     # decision-bearing keys. An unrecognised field is refused rather than
     # ignored, so nothing can ride along unexamined.
-    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"abc123","note":"x"}
-{"reviewer":"fable-5","verdict":"YES","confidence":96,"sha":"abc123","note":"x"}')" \
+    refute_merge "$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"__FIXTURE_SHA__","note":"x"}
+{"reviewer":"fable-5","verdict":"YES","confidence":96,"sha":"__FIXTURE_SHA__","note":"x"}')" \
         "a payload with an unexpected extra key does not merge"
 }
 
@@ -944,8 +1049,8 @@ test_clearance_accepts_two_yes_verdicts() {
     # Non-vacuity control. If this fails, the two tests above prove nothing —
     # they would pass against a gate that rejects everything.
     local r
-    r=$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"abc123"}
-{"reviewer":"fable-5","verdict":"YES","confidence":96,"sha":"abc123"}')
+    r=$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"__FIXTURE_SHA__"}
+{"reviewer":"fable-5","verdict":"YES","confidence":96,"sha":"__FIXTURE_SHA__"}')
     if printf '%s' "$r" | grep -q "GH_MERGE_INVOKED"; then
         pass "two YES verdicts at >=95 bound to the head SHA do clear the merge"
     else
@@ -958,8 +1063,8 @@ test_sub_threshold_message_prescribes_next_action() {
     # must say what to do next; tonight it just refused and the human ran the
     # merge by hand (GH #478).
     local r
-    r=$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"abc123"}
-{"reviewer":"fable-5","verdict":"YES","confidence":93,"sha":"abc123"}')
+    r=$(run_with_clearance '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"__FIXTURE_SHA__"}
+{"reviewer":"fable-5","verdict":"YES","confidence":93,"sha":"__FIXTURE_SHA__"}')
     if printf '%s' "$r" | grep -qi "focused merge-safety round"; then
         pass "a sub-threshold YES prescribes the next action instead of dead-ending"
     else
@@ -999,7 +1104,7 @@ run_hard_deny() {   # "$@" = extra args, already separated
     local tmpdir out code
     tmpdir=$(setup_wrapper_fixture)
     printf 'DIFF_FILES=hooks/codex-gate-check.sh\n' >> "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "review body" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 "$@" 2>&1) && code=0 || code=$?
     printf 'exit=%s %s' "$code" "$out"
@@ -1076,7 +1181,7 @@ test_user_approved_also_clears_the_weaker_ackable_tier() {
     # sourced file cannot assign — which fails closed on a truncated file set.
     printf 'DIFF_FILES=%s\n' "'hooks/codex-gate-check.sh
 CLAUDE_CODE_SDLC_WIZARD.md'" >> "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "review body" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 --user-approved "maintainer decision" 2>&1) && code=0 || code=$?
     rm -rf "$tmpdir"
@@ -1217,10 +1322,19 @@ make_gate_pristine() {   # $1=tmpdir
     git -C "$d" add -A >/dev/null 2>&1
     git -C "$d" -c user.email=t@example.com -c user.name=t commit -qm fixture >/dev/null 2>&1
     git -C "$d" update-ref refs/remotes/origin/main HEAD
+    # This commit MOVES the head, so everything keyed on it must move with it.
+    # Before #540 only the sha mattered and the stub's HEAD_SHA was a constant,
+    # so nothing here needed refreshing; now the clearance also names the tree
+    # that merges, and a stale one reads as "the base moved since
+    # certification" — a true statement about a fixture artifact, not about
+    # anything under test.
+    git -C "$d" rev-parse HEAD > "$d/.fixture-sha"
+    git -C "$d" rev-parse 'HEAD^{tree}' > "$d/.fixture-tree"
+    printf 'HEAD_SHA=%s\n' "$(cat "$d/.fixture-sha")" >> "$d/.gh-stub-config"
 }
 
-DUAL_YES_PAYLOADS='{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"abc123"}
-{"reviewer":"fable-5","verdict":"YES","confidence":96,"sha":"abc123"}'
+DUAL_YES_PAYLOADS='{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"__FIXTURE_SHA__"}
+{"reviewer":"fable-5","verdict":"YES","confidence":96,"sha":"__FIXTURE_SHA__"}'
 
 # Everything a HARD-tier dual-certified merge is supposed to need, all valid.
 # Individual tests then break exactly one thing.
@@ -1229,9 +1343,11 @@ setup_dual_fixture() {   # echoes tmpdir
     tmpdir=$(setup_wrapper_fixture)
     printf 'DIFF_FILES=hooks/codex-gate-check.sh\n' >> "$tmpdir/.gh-stub-config"
     printf 'CLEARANCE_PAYLOADS=%s\n' "$(printf '%q' "$DUAL_YES_PAYLOADS")" >> "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
     echo "review body" > "$tmpdir/.reviews/some-review.md"
     make_gate_pristine "$tmpdir"
+    # AFTER make_gate_pristine, never before: it commits, so it is the last
+    # thing that moves the head and the trees the clearance has to name.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "$tmpdir"
 }
 
@@ -1285,7 +1401,7 @@ test_dual_certified_record_says_attested_not_authenticated
 test_dual_certified_needs_two_distinct_reviewers() {
     local tmpdir
     tmpdir=$(setup_dual_fixture)
-    printf 'CLEARANCE_PAYLOADS=%s\n' "$(printf '%q' '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"abc123"}')" \
+    printf 'CLEARANCE_PAYLOADS=%s\n' "$(printf '%q' '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"__FIXTURE_SHA__"}')" \
         >> "$tmpdir/.gh-stub-config"
     refute_merge "$(run_dual_in "$tmpdir" --dual-certified)" \
         "one reviewer alone does not dual-certify a HARD_DENY path"
@@ -1295,8 +1411,8 @@ test_dual_certified_needs_two_distinct_reviewers
 test_dual_certified_refuses_a_no_verdict() {
     local tmpdir
     tmpdir=$(setup_dual_fixture)
-    printf 'CLEARANCE_PAYLOADS=%s\n' "$(printf '%q' '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"abc123"}
-{"reviewer":"fable-5","verdict":"NO","confidence":96,"sha":"abc123"}')" >> "$tmpdir/.gh-stub-config"
+    printf 'CLEARANCE_PAYLOADS=%s\n' "$(printf '%q' '{"reviewer":"gpt-5.6-sol","verdict":"YES","confidence":97,"sha":"__FIXTURE_SHA__"}
+{"reviewer":"fable-5","verdict":"NO","confidence":96,"sha":"__FIXTURE_SHA__"}')" >> "$tmpdir/.gh-stub-config"
     refute_merge "$(run_dual_in "$tmpdir" --dual-certified)" \
         "one YES and one NO does not dual-certify — disagreement is the human's case, not a merge"
 }
@@ -1308,7 +1424,7 @@ test_dual_certified_refuses_a_no_verdict
 test_dual_certified_still_requires_round_2_artifact() {
     local tmpdir
     tmpdir=$(setup_dual_fixture)
-    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     refute_merge "$(run_dual_in "$tmpdir" --dual-certified)" \
         "a round-1-only clearance artifact still blocks under --dual-certified"
 }
@@ -1496,7 +1612,7 @@ test_wrapper_blocks_a_shadowed_red_validate() {
     local tmpdir out code
     tmpdir=$(setup_wrapper_fixture)
     printf 'EXTRA_VALIDATE_CONCLUSION=failure\n' >> "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "review body" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && code=0 || code=$?
     rm -rf "$tmpdir"
@@ -1515,7 +1631,7 @@ test_wrapper_blocks_an_in_progress_duplicate_validate() {
     local tmpdir out code
     tmpdir=$(setup_wrapper_fixture)
     printf 'EXTRA_VALIDATE_CONCLUSION=null\n' >> "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "review body" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && code=0 || code=$?
     rm -rf "$tmpdir"
@@ -1533,7 +1649,7 @@ test_wrapper_blocks_a_red_validate_on_a_bare_array_page() {
     tmpdir=$(setup_wrapper_fixture)
     printf 'EXTRA_VALIDATE_CONCLUSION=failure\n' >> "$tmpdir/.gh-stub-config"
     printf 'EXTRA_VALIDATE_PAGE_SHAPE=bare\n' >> "$tmpdir/.gh-stub-config"
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "abc123" ".reviews/some-review.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "review body" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && code=0 || code=$?
     rm -rf "$tmpdir"

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -376,7 +376,10 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
             [ "$n" -eq 0 ] && n=1
             echo "$n"; exit 0 ;;
     esac
-    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":${PR_NUM:-123},\"state\":\"OPEN\",\"baseRefName\":\"${BASE_REF:-main}\"}"
+    # baseRefOid is SERVER truth about where the base branch is now. The local
+    # refs/remotes/origin/<base> tracking ref is a cache and can be stale or
+    # absent; both reviewers broke the gate through it in round 1.
+    echo "{\"headRefOid\":\"$HEAD_SHA\",\"number\":${PR_NUM:-123},\"state\":\"OPEN\",\"baseRefName\":\"${BASE_REF:-main}\",\"baseRefOid\":\"${BASE_OID:-$HEAD_SHA}\"}"
     exit 0
 elif [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
     printf '%s\n' "$DIFF_FILES"
@@ -690,6 +693,70 @@ test_wrapper_blocks_moved_base() {
     fi
 }
 
+# Test: the SERVER base moved while the local tracking ref stayed put.
+#
+# Round 1, found independently by BOTH reviewers and constructed rather than
+# argued. The first version of this check read `origin/$BASE_BRANCH^{tree}` — a
+# local cache — and skipped the comparison entirely when that ref was absent.
+# Sol built a bare server repo, advanced server main, left refs/remotes/origin/
+# main at the certified commit, and merged a bogus certification at exit 0.
+# Fable reached the same exit 0 by deleting the ref outright.
+#
+# The base is now read from the PR's baseRefOid, which is server truth. This row
+# is the regression: the local ref deliberately still says "unchanged".
+test_wrapper_blocks_moved_server_base_with_stale_tracking_ref() {
+    local tmpdir out exit_code candidate_sha candidate_tree server_base_sha
+    tmpdir=$(setup_wrapper_fixture)
+    candidate_sha=$(cat "$tmpdir/.fixture-sha")
+    candidate_tree=$(cat "$tmpdir/.fixture-tree")
+
+    printf 'server base moved\n' > "$tmpdir/server-base.txt"
+    git -C "$tmpdir" add server-base.txt
+    git -C "$tmpdir" commit -qm 'move server base'
+    server_base_sha=$(git -C "$tmpdir" rev-parse HEAD)
+
+    # Back to the certified content, and the local tracking ref left lying.
+    git -C "$tmpdir" reset -q --hard "$candidate_sha"
+    git -C "$tmpdir" update-ref refs/remotes/origin/main "$candidate_sha"
+    echo "BASE_OID=$server_base_sha" >> "$tmpdir/.gh-stub-config"
+
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$candidate_sha" ".reviews/some-review.md" \
+        "$candidate_tree" "$candidate_tree"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "the base moved since certification"; then
+        pass "wrapper blocks when the server base moved despite a stale local tracking ref"
+    else
+        fail "stale origin/main authorized a merge past a moved server base: exit=$exit_code out=$out"
+    fi
+}
+
+# Test: the base object named by the PR cannot be read, so nothing can be
+# compared. Same posture as the unreadable remote head ten lines above it —
+# the first version skipped the check instead, which is fail-OPEN in the one
+# situation where the answer is unknown.
+test_wrapper_blocks_unreadable_base_object() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    echo "BASE_OID=ffffffffffffffffffffffffffffffffffffffff" >> "$tmpdir/.gh-stub-config"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    # Asserting the SPECIFIC message, not just a non-zero exit. Neutering the
+    # fail-closed branch leaves CUR_BASE_TREE empty, which the mismatch check
+    # below it then rejects anyway — so an exit-code-only assertion stays green
+    # through the mutation and proves nothing. Measured, not assumed.
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "could not read the tree of the base commit"; then
+        pass "wrapper blocks when the PR's base object cannot be read"
+    else
+        fail "unreadable base object should block on the unreadable-base branch, got exit=$exit_code out=$out"
+    fi
+}
+
 # Test: the pre-#540 artifact format fails closed. A clearance carrying only a
 # sha named no content, and honouring it would be the hole reopened under an
 # older key — the same posture #437 took for a missing commit_sha.
@@ -874,13 +941,17 @@ test_wrapper_blocks_wizard_doc_touch() {
 
 # Test: all conditions pass — wrapper invokes the exact expected merge command
 test_wrapper_merges_when_all_conditions_met() {
-    local tmpdir out exit_code
+    local tmpdir out exit_code fixture_sha
     tmpdir=$(setup_wrapper_fixture)
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
+    # Captured BEFORE the fixture is removed. Reading it afterwards substitutes
+    # the empty string, which leaves a prefix match that passes without ever
+    # checking the SHA — the whole point of this row (Sol, round 1 P2).
+    fixture_sha=$(cat "$tmpdir/.fixture-sha")
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$fixture_sha" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
-    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED: pr merge 123 --squash --match-head-commit $(cat "$tmpdir/.fixture-sha")"; then
+    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED: pr merge 123 --squash --match-head-commit $fixture_sha"; then
         pass "wrapper merges with the exact expected command when all conditions are met"
     else
         fail "wrapper should invoke 'gh pr merge 123 --squash --match-head-commit <fixture sha>', got exit=$exit_code out=$out"
@@ -936,6 +1007,8 @@ test_wrapper_blocks_round_1_only
 test_wrapper_blocks_stale_clearance
 test_wrapper_blocks_wrong_candidate_tree
 test_wrapper_blocks_moved_base
+test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
+test_wrapper_blocks_unreadable_base_object
 test_wrapper_blocks_clearance_without_trees
 test_wrapper_blocks_empty_review_artifact
 test_wrapper_blocks_denylisted_workflow_touch

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -386,6 +386,17 @@ elif [ "$1" = "pr" ] && [ "$2" = "diff" ]; then
     exit 0
 elif [ "$1" = "api" ]; then
     case "$*" in
+        *git/ref/heads/*)
+            # WHERE THE BASE BRANCH IS NOW. Deliberately a DIFFERENT knob from
+            # BASE_OID, which the pr-view stub still emits as `baseRefOid`.
+            # Round 2 read baseRefOid and was wrong: that field is the base
+            # commit ASSOCIATED WITH THE PR, a snapshot that does not move when
+            # the branch does. Measured live on this repo — PR #615 carried
+            # baseRefOid f8ba12b while main was at d0e1c7b. The two knobs are
+            # split here so a row can make them disagree the way GitHub does,
+            # and so reverting the source to baseRefOid stays red forever.
+            echo "{\"object\":{\"sha\":\"${LIVE_BASE_OID:-$HEAD_SHA}\"}}"
+            exit 0 ;;
         *check-runs*)
             # REAL envelope: {"total_count":N,"check_runs":[...]}, one such object
             # per page, which is how `gh --paginate` concatenates pages. Codex
@@ -718,7 +729,11 @@ test_wrapper_blocks_moved_server_base_with_stale_tracking_ref() {
     # Back to the certified content, and the local tracking ref left lying.
     git -C "$tmpdir" reset -q --hard "$candidate_sha"
     git -C "$tmpdir" update-ref refs/remotes/origin/main "$candidate_sha"
-    echo "BASE_OID=$server_base_sha" >> "$tmpdir/.gh-stub-config"
+    # The two knobs DISAGREE, exactly as real GitHub does: baseRefOid stays at
+    # the snapshot the PR was opened against, while the branch itself has moved.
+    # Round 2 read the snapshot and merged; this row is why it cannot again.
+    echo "BASE_OID=$candidate_sha" >> "$tmpdir/.gh-stub-config"
+    echo "LIVE_BASE_OID=$server_base_sha" >> "$tmpdir/.gh-stub-config"
 
     write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$candidate_sha" ".reviews/some-review.md" \
         "$candidate_tree" "$candidate_tree"
@@ -740,7 +755,7 @@ test_wrapper_blocks_moved_server_base_with_stale_tracking_ref() {
 test_wrapper_blocks_unreadable_base_object() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
-    echo "BASE_OID=ffffffffffffffffffffffffffffffffffffffff" >> "$tmpdir/.gh-stub-config"
+    echo "LIVE_BASE_OID=ffffffffffffffffffffffffffffffffffffffff" >> "$tmpdir/.gh-stub-config"
     write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?


### PR DESCRIPTION
Closes #540. First item of #593 Rung 1's merged order (#540 → #521 → #563 → #617 → #504).

## The hole

`hooks/codex-gate-check.sh` keyed staleness on `commit_sha == HEAD`. `PreToolUse` runs **before** the commit, so at check time HEAD is still the certified commit and the gate allows — then the commit lands carrying whatever is staged. **The resulting commit is by construction not the one that was reviewed.** The issue's own stated test — "a fixture that certifies, commits, and asserts the gate refuses; currently it passes, which is the bug" — is row 1 of the new suite, and it failed before this change.

The same key also taxed every commit with a re-pin call (~10 wasted tool calls in one measured cycle) while protecting nothing a content pin does not.

## The mechanism, as ruled

Per #540's reconciled comment of 2026-08-11 (Fable 5 + Sol, independent agreement after one reconcile round), which **amended** the earlier patch-id ruling. Two measurements killed patch-id:

1. Two diffs differing only in the indentation of an added Python line produce the **identical** patch-id. It ignores whitespace by design, and whitespace is semantic in Python, YAML, Makefiles and string literals.
2. What merges is the resulting **tree**, not the diff. A rebase onto moved upstream keeps patch-id identical while producing content nobody read.

So certification names the tree. The hook compares `git write-tree` to `candidate_tree`; `scripts/merge-pr.sh` compares the remote head's tree, and the base it was read against.

**Deliberately preserved:** message-only amend, squash and reorder with no upstream movement all produce the same tree, so certification survives them at zero cost. Rows pin both directions — a guard that only ever refuses is indistinguishable from a broken one.

## Two decisions worth reviewing

**No flag parsing.** `git commit -a` sweeps unstaged changes in, so the committed tree would not be the index's. The fix is not to look for `-a`: requiring a clean tracked worktree makes `git commit` and `git commit -a` commit the same tree. Modelling git's option grammar in a regex is what took #610 from 3 → 6 → 4 before round 4 deleted it.

**`base_tree` is enforced at the merge boundary only.** At commit time the base is HEAD for a normal commit and HEAD^ for an amend, and telling them apart means reading `--amend` off the command line — the same trap. Pinned as row 6, which asserts ALLOW with the reasoning inline.

> **Corrected in round 2.** This paragraph originally justified the deferral with "it costs nothing to defer: a rebase changes the index tree, so the candidate check already refuses it". That is **false**, and Sol falsified it with a running counter-example: when upstream independently produces the candidate's final content, the rebase drops the now-redundant branch change and the index tree does not move (`base_moved hook=0 candidate_same=yes base_changed=yes`). The deferral survives on the narrower ground that `PreToolUse` cannot observe post-command state and the base ref is well-defined only at the merge boundary — which is exactly why that boundary must read live server state rather than any cache.

## Contract change: three suites encoded the old one

- `test-hooks.sh`'s "blocks a stale certification after a new commit" row is now "blocks staged content the certification never saw" — under tree binding a new commit that changes nothing reviewable is exactly the preserved case.
- `test-merge-gate.sh` and `test-cross-model-clearance.sh` used a made-up 40-char head with no git objects behind it, which cannot survive a check that resolves a tree. Both build real ones now.

## Verification

RED first: **3 passed / 5 failed** against the unmodified hook. GREEN: 8/0.

Every guard proven by mutation, not by reading:

| mutation | result |
|---|---|
| hook drops the `!= candidate_tree` half | 8/0 → **6/2** |
| merge gate's candidate_tree compare → `if false` | fixture **merges** (exit 0) |
| merge gate's base_tree compare → `if false` | fixture **merges** (exit 0) |

Suites green: test-hooks 225/0, test-merge-gate 83/0, test-cross-model-clearance 49/0 (baseline 49/0), new suite 8/0, doc-consistency 137/0, workflow-triggers.

Registered in **both** `ci.yml` and `CONTRIBUTING.md` — #610 ran eight review rounds with CI red because a suite reached one and not the other.

Prior art read rather than derived, per the ruling: `codex-sdlc-wizard#111`'s `requireFrozenIndex` + `candidateTree`.
