### PR TITLE
fix(merge-gate): bind ancestry with base_sha, exempt the cleanest round 1 (#563, #636)

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -779,17 +779,285 @@ fi
             echo "BLOCKED: no clearance artifact found at $CLEARANCE_FILE. Run the full cross-model review protocol and write this file, or decide it yourself with --user-approved \"<reason>\"." >&2
             exit 1
         fi
-        CL_STATUS=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"status"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        # ROUND 2 (Sol): A NESTED KEY IS NOT A CONTRACT FIELD.
+        #
+        # Every field below was read as "the first `"name":` anywhere in the
+        # file". JSON nesting made that wrong: an object placed ahead of the
+        # real field supplies the value the gate compares, and the field the
+        # certification actually declares is never read at all.
+        #
+        # Executed against base_sha: live base moved to a different commit,
+        # `"metadata": {"base_sha": "<live>"}` ahead of a stale top-level
+        # `"base_sha": "<old>"`. The nested value matched the live base, the
+        # ancestry check passed, and it merged at exit 0 — #636's hole reopened
+        # by the parser that reads its fix.
+        #
+        # It backed status, round, sha, candidate_tree, base_tree, base_sha and
+        # review_file identically, so this is fixed ONCE, here, rather than
+        # seven times: project the artifact down to depth 1 and read every
+        # contract field from the projection. A nested object collapses to `{}`
+        # and its keys cease to exist as far as the gate is concerned.
+        #
+        # The walk is string-aware — a brace inside a quoted value is data, not
+        # structure — and escape-aware, so a `\"` does not end a string early.
+        # awk rather than a regex because nesting is not a regular language;
+        # any "strip the inner braces" pattern is defeated by one more level.
+        # ROUND 3 (Fable + Sol, converging; DESIGN ESCALATION): STOP
+        # REIMPLEMENTING JSON.
+        #
+        # Rounds 1-3 produced twelve-plus executed artifacts that merged at
+        # exit 0, and every single one was a JSON-GRAMMAR case: nesting,
+        # greedy matching, a `]` inside a string, duplicate keys, keys
+        # smuggled through `\uXXXX` escapes, an unterminated string, trailing
+        # garbage, a numeric token read as a digit prefix. Each round patched
+        # the case it was shown and the next round found the next one. That is
+        # not a hardening backlog, it is the cost curve of hand-writing a JSON
+        # parser in awk and sed — there is always one more case, and both
+        # reviewers are now hunting specifically here.
+        #
+        # THE "NO jq AT THE MERGE BOUNDARY" PREMISE THAT FORCED THE HAND
+        # PARSER IS FALSE, and it was false in this same file: line 133
+        # already refuses to run without jq. This script is repo-local and
+        # never ships (see CLAUDE.md) — the zero-dependency rule protects
+        # consumers, and this has none. python3 is a documented dependency of
+        # this repo's own test suite.
+        #
+        # python3 rather than jq for one specific reason: jq resolves
+        # duplicate keys silently (last wins) and cannot report them, and
+        # duplicates were the single largest defect class across rounds 2 and
+        # 3. `object_pairs_hook` sees the raw pair list and can refuse.
+        #
+        # What this deletes, rather than patches:
+        #   - depth tracking, and every desync that let a nested key print as
+        #     a top-level one (a whole-file parse has no depth counter to
+        #     desync, and refuses the file outright if it does not parse)
+        #   - first-wins vs last-wins ambiguity, for EVERY key at EVERY depth
+        #   - escape smuggling: `reviewers` IS `reviewers` once decoded,
+        #     so an escaped duplicate arrives at the hook as a duplicate
+        #   - digit-prefix number reads: 0.5 is a float and is refused as a
+        #     findings count, rather than parsing as its leading `0`
+        #
+        # THE CONTRACT IS UNCHANGED. Two or more reviewers, all clean, none
+        # dirty; a declared verdict must be CERTIFIED; absence fails closed;
+        # round >= 2 remains a route this branch never touches. Only the
+        # extraction moved.
+        if ! command -v python3 >/dev/null 2>&1; then
+            echo "FAILED CLOSED: python3 is required to parse the clearance artifact. A grep fallback is exactly the parser this replaced, so there is not one." >&2
+            exit 1
+        fi
+        CLEARANCE_PARSED=$(python3 -c '
+import json, re, sys
+
+path = sys.argv[1]
+
+def no_dupes(pairs):
+    seen = set()
+    for k, _ in pairs:
+        if k in seen:
+            # Reported at any depth. A duplicate anywhere means the artifact
+            # has two meanings and parsers disagree about which one is the
+            # certification — the gate refuses rather than picking.
+            raise ValueError("declares the key %r more than once" % k)
+        seen.add(k)
+    return dict(pairs)
+
+def refuse_constant(c):
+    raise ValueError("uses the non-JSON constant %s" % c)
+
+try:
+    with open(path) as fh:
+        doc = json.load(fh, object_pairs_hook=no_dupes, parse_constant=refuse_constant)
+except ValueError as exc:
+    # json.JSONDecodeError subclasses ValueError, so an unbalanced structure,
+    # an unterminated string and trailing garbage all land here alongside the
+    # duplicate-key refusal above.
+    sys.stderr.write("%s\n" % exc)
+    sys.exit(2)
+
+if not isinstance(doc, dict):
+    sys.stderr.write("is not a JSON object\n")
+    sys.exit(2)
+
+_HEX = re.compile(r"[0-9a-f]{40}|[0-9a-f]{64}")
+
+def _is_object_name(v):
+    # SHA-1 today, SHA-256 accepted so a git object-format migration refuses
+    # nothing legitimate. Both are fixed-width lowercase hex.
+    return _HEX.fullmatch(v) is not None
+
+# `review_file` HAS NO GRAMMAR HERE, deliberately. See the comment at the
+# `[ -s ]` check in the shell for why a path grammar on that field is theatre.
+FIELD_GRAMMAR = {
+    "sha": _is_object_name,
+    "candidate_tree": _is_object_name,
+    "base_tree": _is_object_name,
+    "base_sha": _is_object_name,
+}
+FIELD_KIND = {
+    "sha": "git object name",
+    "candidate_tree": "git object name",
+    "base_tree": "git object name",
+    "base_sha": "git object name",
+}
+
+out = []
+def emit(key, value):
+    # The projection is a tab-separated channel and the shell reads it back one
+    # line at a time with `head -1`. Two different attacks live here and BOTH are
+    # closed by refusing the whole control-character class rather than an
+    # enumerated set of separators:
+    #
+    #   tab / newline — inject extra rows. Rows injected through a string field
+    #   precede the derived counts emitted at the end, so an artifact declaring
+    #   no reviewers at all forged "2 reviewers, zero findings".
+    #
+    #   NUL — needs no separator. It is legal JSON, python emits it, and the
+    #   shell DELETES it from a command substitution, so "CERT\0IFIED" and a
+    #   commit sha split by a NUL both normalise to the live value only AFTER
+    #   the parse. What a JSON reader sees in the artifact is then not what the
+    #   gate compares.
+    #
+    # An enumerated set missed NUL, which is the same mistake in miniature that
+    # the hand-written parser kept making: enumerate the cases and the next case
+    # is the one you did not list. Every contract field is a sha, a path, or a
+    # status word, so no C0 control character or DEL is ever legitimate in one.
+    if isinstance(value, str) and any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+        sys.stderr.write("field %r contains a control character\n" % key)
+        sys.exit(2)
+    # THE CLASS REFUSAL ABOVE IS DEFENCE IN DEPTH, NOT THE GUARD. It refuses
+    # what is known to be dangerous, so it fails OPEN whenever that knowledge is
+    # incomplete — which it was twice, at {tab, newline, CR} and again before
+    # NUL was added. The guard proper is below and runs the other way round: a
+    # field must MATCH what it is, so anything unanticipated fails CLOSED. It
+    # also does not depend on modelling shell byte semantics at all, and stays
+    # correct if one of these values later reaches a different sink.
+    if isinstance(value, str) and value and key in FIELD_GRAMMAR:
+        if not FIELD_GRAMMAR[key](value):
+            sys.stderr.write("field %r is not a well-formed %s\n" % (key, FIELD_KIND[key]))
+            sys.exit(2)
+    out.append("%s\t%s" % (key, value))
+
+for key in ("status", "sha", "candidate_tree", "base_tree", "base_sha", "review_file"):
+    value = doc.get(key)
+    # A non-string where a string is required is reported as absent: the
+    # shell already fails closed on absence with a message naming the field,
+    # and inventing a second refusal for "present but wrong type" would say
+    # the same thing twice.
+    emit(key, value if isinstance(value, str) else "")
+
+# bool is an int in Python and `true` is not a round number.
+rnd = doc.get("round")
+emit("round", rnd if isinstance(rnd, int) and not isinstance(rnd, bool) else "")
+
+reviewers = doc.get("reviewers")
+reviewer_count = clean_count = dirty_count = 0
+if isinstance(reviewers, list):
+    for entry in reviewers:
+        if not isinstance(entry, dict):
+            # Still a reviewer, never a clean one — the same direction as an
+            # entry that omits its count.
+            reviewer_count += 1
+            continue
+        reviewer_count += 1
+        if "verdict" in entry and entry["verdict"] != "CERTIFIED":
+            continue
+        total = entry.get("findings_total")
+        if not isinstance(total, int) or isinstance(total, bool) or total < 0:
+            continue
+        if total == 0:
+            clean_count += 1
+        else:
+            dirty_count += 1
+emit("reviewer_count", reviewer_count)
+emit("clean_count", clean_count)
+emit("dirty_count", dirty_count)
+
+sys.stdout.write("\n".join(out))
+' "$CLEARANCE_FILE" 2>&1) || {
+            echo "BLOCKED: $CLEARANCE_FILE does not parse as a certification — $CLEARANCE_PARSED. A file the gate cannot read one way is not a clearance. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        }
+        # One line per key, so the first match is the only match.
+        cl_field() {
+            printf '%s\n' "$CLEARANCE_PARSED" | sed -n "s/^$1	//p" | head -1
+        }
+        CL_STATUS=$(cl_field status)
         if [ "$CL_STATUS" != "CERTIFIED" ]; then
             echo "BLOCKED: $CLEARANCE_FILE status is '${CL_STATUS:-missing}', not CERTIFIED. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
             exit 1
         fi
-        CL_ROUND=$(grep -o '"round"[[:space:]]*:[[:space:]]*[0-9]*' "$CLEARANCE_FILE" | head -1 | sed 's/.*"round"[[:space:]]*:[[:space:]]*//')
+        CL_ROUND=$(cl_field round)
         if [ -z "$CL_ROUND" ] || [ "$CL_ROUND" -lt 2 ]; then
-            echo "BLOCKED: $CLEARANCE_FILE shows round=${CL_ROUND:-missing} — a round-1-only CERTIFIED is treated as an insufficient dialogue (real adversarial review takes at least one recheck round). Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
-            exit 1
+            # #563: THE ONE CASE WHERE round >= 2 IS BACKWARDS.
+            #
+            # The round>=2 rule is sound and stays: one round is usually a
+            # rubber stamp, and the dialogue is where review actually happens.
+            # But it conflates "a dialogue happened" with "the review was
+            # adversarial", and those come apart in exactly one place — both
+            # reviewers certify at round 1 having found NOTHING to dispute.
+            #
+            # PR #562 is the measured instance: Sol zero at every severity at
+            # 99%, Fable zero at every severity at 97%, both verifying the
+            # evidence against primary sources independently. The only way to
+            # satisfy the gate from there was to re-invoke both reviewers and
+            # ask them to re-verify nothing — ceremony that increments a counter
+            # and buys no signal. Two independent clean certifications is
+            # STRONGER evidence than one two-round dialogue, and the gate read
+            # it as weaker.
+            #
+            # The exemption is mechanical — it reads integers, never prose — and
+            # deliberately narrow: TWO OR MORE reviewers, EVERY one at
+            # findings_total 0. One finding at any severity, from any reviewer,
+            # and the recheck round is owed as before.
+            #
+            # ABSENCE IS NOT ZERO. Every artifact written before #563 carries no
+            # findings_total, and silence about findings must never read as an
+            # assertion that there were none, or the exemption applies
+            # retroactively to certifications that never claimed it.
+            #
+            # Trust boundary unchanged and worth stating: the agent writes this
+            # artifact, so the counts are ATTESTED, not authenticated — exactly
+            # the standing of `round` itself. This does not widen that gap.
+            # COUNTED PER REVIEWER ENTRY, NOT PER OCCURRENCE. Round 1 of this
+            # review found the first version grepped every `findings_total` in
+            # the file and never checked the match belonged to a reviewer.
+            # Two counterexamples were executed against it, both merging at
+            # exit 0: an artifact with ZERO reviewer entries and two stray
+            # `findings_total: 0` keys elsewhere, and one with two clean
+            # reviewers plus a third that omits the field entirely. Counting
+            # occurrences answers "are there two zeros in this file", which is
+            # not the question.
+            #
+            # Every entry must carry its own zero. An entry with no
+            # `findings_total` counts as a reviewer and NOT as a clean one, so
+            # partial absence blocks.
+            #
+            # ROUND 3: the counting moved into the strict parse above, with the
+            # slicing-and-splitting it replaced. Three rounds of executed
+            # counterexamples all defeated the EXTRACTION, never the contract —
+            # a regex slice truncating at the first `]`, a greedy prefix taking
+            # the last `"reviewers":[` in the file, a `]` inside a quoted value,
+            # duplicate keys resolved by position, escaped duplicate keys, a
+            # float read as its leading digit. The parser answers all of them
+            # structurally: entries are entries because the JSON says so, a
+            # findings count is an integer or it is not a count, and a verdict
+            # is the value of the verdict key.
+            REVIEWER_COUNT=$(cl_field reviewer_count)
+            CLEAN_COUNT=$(cl_field clean_count)
+            DIRTY_COUNT=$(cl_field dirty_count)
+            # EVERY reviewer clean, and at least two of them. `CLEAN_COUNT -eq
+            # REVIEWER_COUNT` is what closes the partial-absence hole: an entry
+            # that says nothing is counted but never cleared, so it can only
+            # ever refuse.
+            if [ "$CL_ROUND" = "1" ] && [ "$REVIEWER_COUNT" -ge 2 ] \
+                && [ "$CLEAN_COUNT" -eq "$REVIEWER_COUNT" ] && [ "$DIRTY_COUNT" -eq 0 ]; then
+                echo "NOTE: round=1 accepted — $CLEAN_COUNT reviewers each certified with zero findings at every severity (#563). A recheck round would have nothing to be about." >&2
+            else
+                echo "BLOCKED: $CLEARANCE_FILE shows round=${CL_ROUND:-missing} — a round-1-only CERTIFIED is treated as an insufficient dialogue (real adversarial review takes at least one recheck round). The one exemption is two or more reviewers each recording findings_total=0; this artifact declares $REVIEWER_COUNT reviewer entries, $CLEAN_COUNT of them recording zero findings and $DIRTY_COUNT recording findings — an entry that records nothing counts toward neither (#563). Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+                exit 1
+            fi
         fi
-        CL_SHA=$(grep -o '"sha"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"sha"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        CL_SHA=$(cl_field sha)
         if [ "$CL_SHA" != "$HEAD_SHA" ]; then
             echo "BLOCKED: $CLEARANCE_FILE is stale — its sha ($CL_SHA) does not match the current remote head ($HEAD_SHA). New commits landed since certification. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
             exit 1
@@ -824,7 +1092,7 @@ fi
         # Fails closed on a missing field: an artifact naming no content is the
         # pre-#540 format, and honouring it would be the hole reopened under an
         # older key.
-        CL_CAND_TREE=$(grep -o '"candidate_tree"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"candidate_tree"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        CL_CAND_TREE=$(cl_field candidate_tree)
         if [ -z "$CL_CAND_TREE" ]; then
             echo "BLOCKED: $CLEARANCE_FILE declares no 'candidate_tree'. A certification names the content it was issued over, not just the commit it happened to sit on (#540). Record it with: git rev-parse 'HEAD^{tree}'. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
             exit 1
@@ -847,7 +1115,7 @@ fi
         # base_tree pins WHICH BASE the reviewers read. A rebase onto moved
         # upstream can leave candidate_tree untouched while the integration
         # result changes, which is the second measurement that killed patch-id.
-        CL_BASE_TREE=$(grep -o '"base_tree"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"base_tree"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        CL_BASE_TREE=$(cl_field base_tree)
         if [ -z "$CL_BASE_TREE" ]; then
             echo "BLOCKED: $CLEARANCE_FILE declares no 'base_tree'. A certification names the base it was read against, or a rebase onto moved upstream carries it silently (#540). Record it with: git rev-parse \"origin/\$BASE_BRANCH^{tree}\". Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
             exit 1
@@ -869,7 +1137,65 @@ fi
             echo "BLOCKED: the base moved since certification — $BASE_BRANCH tree is $CUR_BASE_TREE, certified base_tree is $CL_BASE_TREE. The reviewers read a different base, and the merged result is not what they cleared (#540). Rebase and re-review, or decide it yourself: --user-approved \"<reason>\"." >&2
             exit 1
         fi
-        CL_REVIEW_FILE=$(grep -o '"review_file"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLEARANCE_FILE" | head -1 | sed 's/.*"review_file"[[:space:]]*:[[:space:]]*"//; s/"$//')
+        # #636: A TREE CARRIES NO ANCESTRY, AND base_tree IS A TREE.
+        #
+        # #540 replaced SHA identity with content identity, and that was right.
+        # But it bound the content at the two ENDPOINTS and modelled the base as
+        # a tree. The base is a POSITION IN A HISTORY. A PR diff is three-dot,
+        # so what actually merges depends on the MERGE BASE — and the merge base
+        # can move while `sha`, `candidate_tree` and `base_tree` are all still
+        # byte-identical.
+        #
+        # The case, reproduced with real git objects during #521's design
+        # review rather than argued: main takes a commit the PR also contains,
+        # then REVERTS it. Main's tree returns byte-for-byte to what the
+        # reviewers read, so base_tree matches. The PR head never moved, so
+        # candidate_tree matches. But the merge base advanced past the reverted
+        # commit, so the PR now contributes only the part the revert did not
+        # undo. Measured: reviewed base tree == live base tree, candidate tree
+        # matched, and `git merge-tree` produced a prospective merge containing
+        # HALF the reviewed content. Every check above passed. It merged at
+        # exit 0.
+        #
+        # base_sha is the conservative fix: it subsumes base_tree entirely
+        # (same commit implies same tree), so the tree check above is now
+        # strictly redundant. It is kept anyway — removing it is contract churn
+        # for no safety gain, and its refusal message is the more legible one
+        # when a genuine rebase is what moved.
+        #
+        # Fails closed when absent, for the same reason candidate_tree does: an
+        # artifact that says nothing about the base is the pre-#636 format, and
+        # honouring it leaves the hole open forever behind an omitted field.
+        # Nothing live breaks — clearances are per-PR and written fresh.
+        CL_BASE_SHA=$(cl_field base_sha)
+        if [ -z "$CL_BASE_SHA" ]; then
+            echo "BLOCKED: $CLEARANCE_FILE declares no 'base_sha'. A tree carries no ancestry, so base_tree alone cannot tell a moved base from a still one — a revert returns the base tree to its old value while the merge base advances (#636). Record it with: git rev-parse \"origin/\$BASE_BRANCH\". Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        if [ "$CL_BASE_SHA" != "$BASE_SHA" ]; then
+            echo "BLOCKED: the base branch moved since certification — $BASE_BRANCH is at $BASE_SHA, certified base_sha is $CL_BASE_SHA. The trees may still match (a revert does exactly that), but the merge base moved, so what merges is not what was reviewed (#636). Rebase and re-review, or decide it yourself: --user-approved \"<reason>\"." >&2
+            exit 1
+        fi
+        CL_REVIEW_FILE=$(cl_field review_file)
+        # EXISTENCE AND NON-EMPTINESS IS THE WHOLE CHECK, ON PURPOSE. Nothing
+        # binds this file's CONTENT to this PR, this round, or these reviewers,
+        # so any non-empty tracked file satisfies it — `README.md` does. That
+        # makes every question about the path's PEDIGREE theatre: refusing a
+        # path that escapes the repository denies an artifact author nothing,
+        # because the identical check is satisfied by a file already inside it.
+        #
+        # A grammar and a realpath containment check lived here for three review
+        # rounds and were deleted (#645). They bought no security property any
+        # test could state, and they cost false refusals — a legal `-review.md`,
+        # a legitimate in-repo symlink, and any invocation from a subdirectory
+        # were all blocked. A false refusal in a merge gate is worse than dead
+        # code: it trains `--user-approved` overrides and erodes the gate it
+        # lives in. Do not re-add a path check here. The real fix is to bind the
+        # CONTENT — a digest in the artifact, or a file that must name the sha
+        # and round — and that is #645, not a spelling rule.
+        #
+        # `review_file`'s in-scope surface is the projection channel, and the
+        # control-character class refusal in emit() still covers that.
         if [ -z "$CL_REVIEW_FILE" ] || [ ! -s "$CL_REVIEW_FILE" ]; then
             echo "BLOCKED: $CLEARANCE_FILE's referenced review artifact ('$CL_REVIEW_FILE') is missing or empty — can't verify the dialogue was substantive. Explicit user confirmation is required: --user-approved \"<reason>\"." >&2
             exit 1

--- a/tests/test-cross-model-clearance.sh
+++ b/tests/test-cross-model-clearance.sh
@@ -180,10 +180,16 @@ STUB
     echo "$tmpdir"
 }
 
+# #636 added base_sha to the enforced contract, so every artifact this suite
+# writes needs it or the wrapper fails closed before reaching the checks these
+# rows are actually about. Defaults to the fixture's real base — these tests are
+# about clearance COMMENTS, not about ancestry; arg 5 exists for a row that
+# wants to say otherwise.
 write_clearance_artifact() {
     cat > "$1/.reviews/merge-clearance-123.json" <<JSON
 { "pr_number": 123, "status": "CERTIFIED", "round": 4, "sha": "$2",
   "candidate_tree": "${3:-$HEAD_TREE}", "base_tree": "${4:-$HEAD_TREE}",
+  "base_sha": "${5:-$HEAD_SHA}",
   "review_file": ".reviews/r.md" }
 JSON
     echo "review body" > "$1/.reviews/r.md"

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -328,6 +328,22 @@ setup_wrapper_fixture() {
     # actually targets, read from the PR itself rather than assumed.
     git -C "$tmpdir" update-ref refs/remotes/origin/main HEAD
 
+    # #636: A SECOND COMMIT WITH THE IDENTICAL TREE. This is the minimal
+    # instance of the ancestry class — the base MOVED, and every field #540
+    # enforces still matches, because a tree carries no ancestry.
+    #
+    # The real-world trigger is a revert: main takes a commit the PR also
+    # contains, then reverts it, and main's tree returns byte-for-byte to where
+    # the reviewers read it while the merge base advances past it. An empty
+    # commit reproduces the same fields (new sha, same tree) in one line
+    # instead of four, and the gate cannot tell the two apart — which is the
+    # point.
+    git -C "$tmpdir" commit -q --allow-empty -m "base moved, tree identical"
+    git -C "$tmpdir" rev-parse HEAD > "$tmpdir/.fixture-base-moved-sha"
+    # Rewound so this commit is reachable-but-not-current: only rows that
+    # deliberately point the live base at it are affected.
+    git -C "$tmpdir" reset -q --hard "$(cat "$tmpdir/.fixture-sha")"
+
     # Control file the stub gh reads: one KEY=VALUE per line.
     # HEAD_SHA, VALIDATE_CONCLUSION, DIFF_FILES (newline-separated, base64
     # would be overkill — use a sentinel-delimited list), DELETED_TEST_FILES,
@@ -519,17 +535,55 @@ write_clearance() {
     # content that is deliberately wrong.
     local cand="${7:-$(cat "$tmpdir/.fixture-tree")}"
     local base="${8:-$(cat "$tmpdir/.fixture-tree")}"
-    cat > "$tmpdir/.reviews/merge-clearance-$pr.json" <<JSON
-{
-  "pr_number": $pr,
-  "status": "$status",
-  "round": $round,
-  "sha": "$sha",
-  "candidate_tree": "$cand",
-  "base_tree": "$base",
-  "review_file": "$review_file"
+    # #563: arg 9 is a raw `reviewers` array body. DELIBERATELY EMPTY BY
+    # DEFAULT, and that default is load-bearing: every artifact written before
+    # #563 carries no findings_total at all, and those must keep taking the
+    # round >= 2 path unchanged. A default of "two reviewers at zero" would
+    # silently hand every existing round-1 row the new exemption and hide the
+    # fail-closed behaviour this field exists to have.
+    local reviewers="${9:-}"
+    # #636: WHERE the base was, not just what it contained. Defaults to the
+    # fixture's real base commit so every pre-existing row keeps testing what it
+    # was written to test. Deliberately independent of arg 5 — several rows pass
+    # a deliberately stale head sha there, and the base is a separate fact.
+    local base_sha="${10:-$(cat "$tmpdir/.fixture-sha")}"
+    # Round 2 (Sol): arg 11 is raw JSON emitted BEFORE every contract field, so
+    # a row can place a NESTED object carrying the same key names ahead of the
+    # real ones. Order is the whole point — the reader took the first match in
+    # the file, so a nested value only masks a top-level one by preceding it.
+    local extra="${11:-}"
+    # Arg 12 is the same thing AFTER the reviewers array. Both positions are
+    # needed and neither substitutes: `head -1` reads the FIRST occurrence and
+    # a greedy `.*` reads the LAST, so a masking value has to be placed on the
+    # correct side of the real field to reproduce each defect.
+    local extra_after="${12:-}"
+    {
+        printf '{\n'
+        printf '  "pr_number": %s,\n' "$pr"
+        [ -n "$extra" ] && printf '  %s,\n' "$extra"
+        printf '  "status": "%s",\n' "$status"
+        printf '  "round": %s,\n' "$round"
+        printf '  "sha": "%s",\n' "$sha"
+        printf '  "candidate_tree": "%s",\n' "$cand"
+        printf '  "base_tree": "%s",\n' "$base"
+        printf '  "base_sha": "%s",\n' "$base_sha"
+        [ -n "$reviewers" ] && printf '  "reviewers": [%s],\n' "$reviewers"
+        [ -n "$extra_after" ] && printf '  %s,\n' "$extra_after"
+        printf '  "review_file": "%s"\n' "$review_file"
+        printf '}\n'
+    } > "$tmpdir/.reviews/merge-clearance-$pr.json"
 }
-JSON
+
+# #563 helper: a reviewers-array body with N entries, each at findings_total=$2.
+# Kept as a function rather than inline JSON so a row states its INTENT ("two
+# reviewers, both clean") instead of a wall of braces that has to be re-read.
+reviewers_with() {
+    local count="$1" total="$2" i out=""
+    for i in $(seq 1 "$count"); do
+        [ -n "$out" ] && out="$out,"
+        out="$out{\"model\":\"r$i\",\"verdict\":\"CERTIFIED\",\"confidence\":97,\"findings_total\":$total}"
+    done
+    printf '%s' "$out"
 }
 
 # Test: wrapper script exists and is executable (guards the tests below —
@@ -659,6 +713,1006 @@ test_wrapper_blocks_round_1_only() {
         pass "wrapper blocks a round-1-only CERTIFIED as insufficient dialogue"
     else
         fail "wrapper should block round=1 CERTIFIED, got exit=$exit_code out=$out"
+    fi
+}
+
+# --- #636: a tree carries no ancestry ---
+#
+# #540 bound certification to CONTENT rather than to a SHA, and that was right.
+# But it bound the content at the two ENDPOINTS and modelled the base as a tree.
+# The base is a POSITION IN A HISTORY. A PR diff is three-dot, so what actually
+# merges depends on the merge base — and the merge base can move while `sha`,
+# `candidate_tree` and `base_tree` all stay byte-identical.
+#
+# Reproduced with real git objects during #521's design review: reviewed base
+# tree matched live, candidate tree matched, and `git merge-tree` produced a
+# prospective merge containing only HALF the reviewed content.
+test_wrapper_blocks_moved_base_with_identical_tree() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # The live base is a DIFFERENT commit with the SAME tree. Every field the
+    # gate enforces today matches; only ancestry moved.
+    echo "LIVE_BASE_OID=$(cat "$tmpdir/.fixture-base-moved-sha")" >> "$tmpdir/.gh-stub-config"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    # Asserting the SPECIFIC refusal. A generic non-zero exit would also be
+    # satisfied by the tree-mismatch check further down, which cannot fire here
+    # by construction — the trees are equal, that is the whole scenario.
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "base_sha"; then
+        pass "wrapper blocks when the base moved to a commit with an identical tree"
+    else
+        fail "wrapper should block a moved base with an identical tree, got exit=$exit_code out=$out"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# ROUND 2 (Sol, P1): A NESTED KEY IS NOT A CONTRACT FIELD.
+#
+# Every contract field was read with `grep -o '"field".."' | head -1` — the
+# FIRST occurrence anywhere in the file, at any nesting depth. So an object
+# nested ahead of the real field supplies the value the gate compares, and the
+# top-level field the certification actually declares is never read.
+#
+# Sol executed this against base_sha: live base moved to a different commit,
+# `"metadata": {"base_sha": "<live>"}` placed before a stale top-level
+# `"base_sha": "<old>"`. The nested value matched the live base, so the ancestry
+# check passed and it merged at exit 0 — the exact hole #636 exists to close,
+# reopened by the parser reading it.
+#
+# It is a CLASS defect, not one field's: the same read shape backs status,
+# round, sha, candidate_tree, base_tree and review_file. Rows below cover the
+# two that authorize content and ancestry; fixing only the one Sol demonstrated
+# would leave the other five standing.
+test_wrapper_blocks_nested_base_sha_masking_a_stale_one() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    echo "LIVE_BASE_OID=$(cat "$tmpdir/.fixture-base-moved-sha")" >> "$tmpdir/.gh-stub-config"
+    # Top-level base_sha is the ORIGINAL base — stale, and the gate must refuse
+    # on it. The nested one matches the live base and must be invisible.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" "" "$(cat "$tmpdir/.fixture-sha")" \
+        "\"metadata\": {\"base_sha\": \"$(cat "$tmpdir/.fixture-base-moved-sha")\"}"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "base branch moved"; then
+        pass "wrapper ignores a nested base_sha and refuses on the top-level one"
+    else
+        fail "wrapper should read base_sha only at the top level, got exit=$exit_code out=$out"
+    fi
+}
+
+test_wrapper_blocks_nested_candidate_tree_masking_a_stale_one() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Same shape, different field — this is the one that binds CONTENT. The
+    # top-level candidate_tree certifies a tree that is not what would merge.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "0000000000000000000000000000000000000000" "" "" "" \
+        "\"metadata\": {\"candidate_tree\": \"$(cat "$tmpdir/.fixture-tree")\"}"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "not the content that was certified"; then
+        pass "wrapper ignores a nested candidate_tree and refuses on the top-level one"
+    else
+        fail "wrapper should read candidate_tree only at the top level, got exit=$exit_code out=$out"
+    fi
+}
+
+# ROUND 2 (Sol, P1): the verdict check matched "CERTIFIED" ANYWHERE in the
+# entry rather than as the value OF the verdict key. A reviewer declaring
+# NOT_CERTIFIED alongside any other field whose value happens to contain the
+# word — a note, a filename, a quoted refusal message — was counted as clean.
+# Sol executed it: `"verdict":"NOT_CERTIFIED","note":"CERTIFIED"` took the
+# round-1 exemption and merged at exit 0.
+test_wrapper_blocks_round_1_when_certified_appears_outside_the_verdict() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0},{"model":"r2","verdict":"NOT_CERTIFIED","note":"CERTIFIED","findings_total":0}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "wrapper reads CERTIFIED as the verdict's value, not as text anywhere in the entry"
+    else
+        fail "wrapper should block a NOT_CERTIFIED reviewer whose other fields contain 'CERTIFIED', got exit=$exit_code out=$out"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# ROUND 2 (Fable, P1/P2): THE REVIEWERS SLICE WAS A REGEX, AND AN ARRAY IS NOT
+# A REGULAR LANGUAGE.
+#
+# The block was cut with `sed 's/.*"reviewers"...\[\([^]]*\)\].*/\1/'`. Two
+# executed counterexamples merged at exit 0:
+#
+#   PROBE-A: `[^]]*` stops at the FIRST `]` in the file. A nested array inside
+#   an early clean entry (`"tags":[1]`) truncated the block there, so a LATER
+#   entry recording five findings was never seen. Two clean reviewers, zero
+#   dirty, exemption granted — while a reviewer had findings.
+#
+#   PROBE-B: the leading `.*` is greedy, so it takes the LAST `"reviewers":[`
+#   in the file. A nested `history.round0.reviewers` array of clean entries
+#   overrode the real top-level array holding one NOT_CERTIFIED reviewer with
+#   four findings.
+#
+# Round 1's "fail closed by construction" was argued for nested OBJECTS and is
+# false for nested ARRAYS and duplicate keys. It is also false for a `]` inside
+# a quoted string, which neither probe used and which truncates identically —
+# so the block is now extracted by a depth- and string-aware walk rather than
+# hardened case by case, and a duplicate top-level key is refused as ambiguous.
+test_wrapper_blocks_round_1_when_a_nested_array_hides_a_dirty_reviewer() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0},{"model":"r2","verdict":"CERTIFIED","findings_total":0,"tags":[1]},{"model":"r3","verdict":"CERTIFIED","findings_total":5}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a nested array in one entry does not truncate the reviewers block"
+    else
+        fail "wrapper should see the dirty third reviewer past a nested array, got exit=$exit_code out=$out"
+    fi
+}
+
+test_wrapper_blocks_round_1_when_a_string_bracket_hides_a_dirty_reviewer() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Same truncation, no nesting at all — a `]` inside a quoted value. This is
+    # the variant a "refuse blocks containing [" guard would let through.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0},{"model":"r2","verdict":"CERTIFIED","findings_total":0,"note":"see [1] above]"},{"model":"r3","verdict":"CERTIFIED","findings_total":7}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a ']' inside a quoted value does not truncate the reviewers block"
+    else
+        fail "wrapper should see the dirty third reviewer past a bracket in a string, got exit=$exit_code out=$out"
+    fi
+}
+
+test_wrapper_blocks_round_1_when_a_nested_reviewers_array_shadows_the_real_one() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # The REAL array is one NOT_CERTIFIED reviewer with findings. A nested
+    # history block afterwards holds two clean ones.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"sol","verdict":"NOT_CERTIFIED","findings_total":4}' "" "" \
+        '"history": {"round0": {"reviewers": [{"model":"a","verdict":"CERTIFIED","findings_total":0},{"model":"b","verdict":"CERTIFIED","findings_total":0}]}}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a nested reviewers array does not shadow the top-level one"
+    else
+        fail "wrapper should read the top-level reviewers array, got exit=$exit_code out=$out"
+    fi
+}
+
+test_wrapper_blocks_round_1_on_duplicate_reviewers_keys() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Two top-level reviewers keys. JSON parsers disagree about which wins, so
+    # the gate refuses rather than picking — a certification that cannot be
+    # read one way is not a certification.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" "$(reviewers_with 2 0)" "" \
+        '"reviewers": [{"model":"x","verdict":"NOT_CERTIFIED","findings_total":9}]'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "more than once"; then
+        pass "two top-level reviewers keys are refused as ambiguous"
+    else
+        fail "wrapper should refuse a duplicated reviewers key, got exit=$exit_code out=$out"
+    fi
+}
+
+# The counterpart the refusals above would otherwise be satisfied by: a nested
+# array in an entry is LEGAL JSON, and a clearance carrying one must still take
+# the exemption. Without this row, "block anything containing a bracket" would
+# pass every test above while being wrong.
+test_wrapper_allows_round_1_two_clean_reviewers_with_a_nested_array() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0,"tags":["a","b"]},{"model":"r2","verdict":"CERTIFIED","findings_total":0}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "two clean reviewers still take the exemption when an entry carries a nested array"
+    else
+        fail "a legal nested array should not defeat the exemption, got exit=$exit_code out=$out"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# ROUND 3 (Fable + Sol, converging): AMBIGUITY WAS RESOLVED BY POSITION INSTEAD
+# OF REFUSED, AND NEITHER WALK CHECKED WHETHER IT HAD PARSED ANYTHING.
+#
+# Round 2 established the principle in two places — a duplicated top-level
+# `reviewers` key and a duplicated `verdict` inside an entry are REFUSED rather
+# than resolved. The principle was right and was applied to exactly those two
+# keys; every other key kept reading first-wins, which is the opposite of what
+# a JSON parser does. Nine artifacts were executed against that gap and all
+# nine merged at exit 0.
+#
+# These rows are what forced the design escalation: the fix is no longer a
+# hand-written walk but a strict parse, so the rows below are the specification
+# that parse has to meet.
+raw_clearance() {
+    cat > "$1/.reviews/merge-clearance-123.json"
+    echo "content" > "$1/.reviews/some-review.md"
+}
+
+# The entry says zero, then says seven. First-wins read it as clean; a JSON
+# parser reads seven. The exemption was granted to an artifact with findings.
+test_wrapper_blocks_round_1_on_duplicate_findings_total_in_an_entry() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0,"findings_total":7},{"model":"r2","verdict":"CERTIFIED","findings_total":0}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "an entry declaring findings_total twice is refused, not resolved first-wins"
+    else
+        fail "duplicate findings_total in an entry should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# 0.5 is valid JSON and is not zero. A digit-PREFIX match read it as 0.
+test_wrapper_blocks_round_1_on_a_non_integer_findings_total() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0.5},{"model":"r2","verdict":"CERTIFIED","findings_total":0.5}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a non-integer findings_total does not parse as its leading digit"
+    else
+        fail "findings_total 0.5 should not count as zero, got exit=$exit_code out=$out"
+    fi
+}
+
+# 0.0 is the discriminating case for the TYPE check specifically: it equals
+# zero numerically, so a guard that only compares values still clears it. Only
+# a guard that requires an INTEGER refuses. Without this row the type check
+# survives its own mutation — which is how it shipped untested the first time.
+test_wrapper_blocks_round_1_on_a_float_zero_findings_total() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0.0},{"model":"r2","verdict":"CERTIFIED","findings_total":0.0}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "findings_total 0.0 is not an integer count, even though it equals zero"
+    else
+        fail "a float zero findings_total should not clear, got exit=$exit_code out=$out"
+    fi
+}
+
+# A reviewers entry that is not an object at all. It is still a reviewer and
+# never a clean one — the same direction as an entry omitting its count.
+# Discriminates the "count it anyway" branch, which is otherwise unreachable.
+test_wrapper_blocks_round_1_when_a_reviewers_entry_is_not_an_object() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0},{"model":"r2","verdict":"CERTIFIED","findings_total":0},"a bare string"'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a non-object reviewers entry counts as a reviewer and never as a clean one"
+    else
+        fail "a bare string in the reviewers array should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# status CERTIFIED, then status NOT_CERTIFIED. Pre-existing first-wins read,
+# swept in rather than deferred because the same commit rewrote this read.
+test_wrapper_blocks_duplicate_status_keys() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "status": "NOT_CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "more than once"; then
+        pass "a duplicated top-level status key is refused as ambiguous"
+    else
+        fail "duplicate status keys should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# The same shape on the field #636 exists to bind: live base first, stale base
+# second. The gate cleared an ancestry the artifact's JSON meaning does not name.
+test_wrapper_blocks_duplicate_base_sha_keys() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "base_sha": "0000000000000000000000000000000000000000",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "more than once"; then
+        pass "a duplicated top-level base_sha key is refused as ambiguous"
+    else
+        fail "duplicate base_sha keys should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# The parse is strict; the CHANNEL it writes to was not. Contract fields are
+# projected as "key\tvalue" lines and read back with `head -1`, and the three
+# derived counts are emitted last. A string value carrying a newline and tabs
+# injects earlier count rows that win the `head -1` read, so an artifact
+# declaring NO reviewers at all takes the round-1 exemption as "2 reviewers,
+# zero findings". Legal JSON throughout — \n and \t are standard escapes, so
+# nothing upstream of the projection can see it.
+test_wrapper_blocks_tsv_injection_through_a_string_field() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 1,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")\nreviewer_count\t2\nclean_count\t2\ndirty_count\t0",
+  "review_file": ".reviews/some-review.md",
+  "reviewers": []
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a control character in a projected string field cannot forge the reviewer counts"
+    else
+        fail "TSV injection through base_sha should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# The same seam aimed at ANCESTRY rather than at the counts. `status` is emitted
+# first, so rows injected through it win the `head -1` read for every field that
+# follows — including the three #636 binds. The artifact's real sha, trees and
+# base_sha are all garbage; the injected rows supply live ones.
+test_wrapper_blocks_tsv_injection_forging_the_ancestry_binds() {
+    local tmpdir out exit_code sha tree
+    tmpdir=$(setup_wrapper_fixture)
+    sha=$(cat "$tmpdir/.fixture-sha")
+    tree=$(cat "$tmpdir/.fixture-tree")
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED\nsha\t$sha\ncandidate_tree\t$tree\nbase_tree\t$tree\nbase_sha\t$sha\nreview_file\t.reviews/some-review.md",
+  "round": 2,
+  "sha": "0000000000000000000000000000000000000000",
+  "candidate_tree": "0000000000000000000000000000000000000000",
+  "base_tree": "0000000000000000000000000000000000000000",
+  "base_sha": "0000000000000000000000000000000000000000",
+  "review_file": ".reviews/nonexistent-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a control character in status cannot forge the content and ancestry binds"
+    else
+        fail "TSV injection through status should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# The other half of the same seam, and it does not need a row separator. NUL is
+# legal JSON (\u0000), python emits it, and the shell DELETES it from a command
+# substitution. So every string bind can be written with a NUL in the middle and
+# normalize to the live value only after the parse: what a JSON reader sees in
+# the artifact is not what the gate compares. Refusing an enumerated set of
+# separators misses this; the refusal has to be the whole control-character
+# class.
+test_wrapper_blocks_nul_normalising_a_string_field() {
+    local tmpdir out exit_code sha tree
+    tmpdir=$(setup_wrapper_fixture)
+    sha=$(cat "$tmpdir/.fixture-sha")
+    tree=$(cat "$tmpdir/.fixture-tree")
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERT\u0000IFIED",
+  "round": 2,
+  "sha": "${sha:0:20}\u0000${sha:20}",
+  "candidate_tree": "${tree:0:20}\u0000${tree:20}",
+  "base_tree": "${tree:0:20}\u0000${tree:20}",
+  "base_sha": "${sha:0:20}\u0000${sha:20}",
+  "review_file": ".reviews/some\u0000-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a NUL byte cannot normalise a string field into a live value after the parse"
+    else
+        fail "NUL normalisation should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# The row above is NOT sufficient, and this row exists because review proved it.
+# That artifact puts a NUL in `sha` as well, so it is refused by the object-name
+# grammar and the control-character class refusal is never reached: narrow the
+# class back to {tab, newline, CR} and the suite still goes fully green. `status`
+# is the only field the class refusal SOLELY guards — no grammar constrains it —
+# so the isolation has to be a NUL in status with every other field clean.
+# Under the narrowed class this artifact merges at exit 0, which is the round-5
+# normalisation exploit intact.
+test_wrapper_blocks_nul_in_status_with_every_other_field_clean() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERT\u0000IFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "contains a control character"; then
+        pass "the control-character class refusal is proven on the one field it solely guards"
+    else
+        fail "a NUL in status alone should block via the class refusal, got exit=$exit_code out=$out"
+    fi
+}
+
+# The object-name grammar is NOT load-bearing for safety and this row says so
+# honestly: a non-hex sha never matched the live head anyway, so the staleness
+# comparison already blocked it. What the grammar changes is WHERE and WHY it is
+# refused — at the parse, named as malformed, before any comparison runs. That
+# is the behaviour asserted here, and it is the only thing about this guard that
+# is provable today. Its real value is invariance if one of these values ever
+# reaches a different sink; that value cannot be tested until such a sink
+# exists, and is disclosed in known_limits rather than claimed.
+test_wrapper_refuses_a_malformed_object_name_at_the_parse() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "not-a-real-object-name" ".reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "not a well-formed git object name"; then
+        pass "a malformed object name is refused at the parse, not at the comparison"
+    else
+        fail "malformed sha should be refused as malformed, got exit=$exit_code out=$out"
+    fi
+}
+
+# POSITIVE ROW, and the only survivor of the deleted path guard (#645). The
+# grammar and the realpath containment check that used to run on review_file are
+# gone: they bought no security property any test could state, because nothing
+# binds this file's CONTENT to anything, and they cost false refusals. This row
+# is what stops them coming back. Any path check re-added here fails it, since a
+# space is legal in a repository path and every such rule refused it. It asserts
+# a criterion-4 property — a legitimate round >= 2 artifact still merges — which
+# survives the guard's deletion because it was never about the guard.
+test_wrapper_allows_a_review_file_path_containing_a_space() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    echo "content" > "$tmpdir/.reviews/review notes.md"
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/review notes.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a legitimate review_file path containing a space still merges"
+    else
+        fail "a space in a repo-relative review_file should merge, got exit=$exit_code out=$out"
+    fi
+}
+
+# The object-name grammar was mapped over four fields and only `sha` was rowed,
+# so deleting the other three mappings left the suite green. One row per field.
+test_wrapper_refuses_a_malformed_candidate_tree() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" "not-a-tree"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && echo "$out" | grep -q "candidate_tree.*not a well-formed"; then
+        pass "a malformed candidate_tree is refused at the parse"
+    else
+        fail "malformed candidate_tree should be refused, got exit=$exit_code out=$out"
+    fi
+}
+
+test_wrapper_refuses_a_malformed_base_tree() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "$(cat "$tmpdir/.fixture-tree")" "not-a-tree"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && echo "$out" | grep -q "base_tree.*not a well-formed"; then
+        pass "a malformed base_tree is refused at the parse"
+    else
+        fail "malformed base_tree should be refused, got exit=$exit_code out=$out"
+    fi
+}
+
+test_wrapper_refuses_a_malformed_base_sha() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "not-a-base",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && echo "$out" | grep -q "base_sha.*not a well-formed"; then
+        pass "a malformed base_sha is refused at the parse"
+    else
+        fail "malformed base_sha should be refused, got exit=$exit_code out=$out"
+    fi
+}
+
+# Round 2's duplicate-reviewers refusal counted only captures that OPEN a
+# bracket, so a second `reviewers` whose value is a string was invisible.
+# Under a real parser this artifact has no reviewer entries at all.
+test_wrapper_blocks_duplicate_reviewers_key_with_a_non_array_value() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 1,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "reviewers": [{"model":"r1","verdict":"CERTIFIED","findings_total":0},{"model":"r2","verdict":"CERTIFIED","findings_total":0}],
+  "reviewers": "superseded",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a duplicated reviewers key is refused even when the second value is not an array"
+    else
+        fail "a non-array duplicate reviewers key should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# THE WALKS NEVER CHECKED THEIR OWN END STATE. A stray leading `]` drove depth
+# to -1, so every real depth was offset by one and a NESTED base_sha printed
+# into the "depth-1" projection ahead of the honest top-level one — Sol's
+# round-2 hole, reopened through the code written to close it.
+test_wrapper_blocks_a_clearance_whose_braces_do_not_balance() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    echo "LIVE_BASE_OID=$(cat "$tmpdir/.fixture-base-moved-sha")" >> "$tmpdir/.gh-stub-config"
+    raw_clearance "$tmpdir" <<JSON
+]
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "metadata": {"base_sha": "$(cat "$tmpdir/.fixture-base-moved-sha")"},
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "does not parse"; then
+        pass "an artifact whose structure does not balance is refused before any field is read"
+    else
+        fail "unbalanced structure should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# Same hole, different desync: an unterminated string flips quote parity, the
+# nested object's braces read as string data, and its base_sha prints into the
+# projection ahead of the honest one.
+test_wrapper_blocks_a_clearance_with_an_unterminated_string() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    echo "LIVE_BASE_OID=$(cat "$tmpdir/.fixture-base-moved-sha")" >> "$tmpdir/.gh-stub-config"
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "pad": "unterminated,
+  "metadata": {"base_sha": "$(cat "$tmpdir/.fixture-base-moved-sha")"},
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "does not parse"; then
+        pass "an artifact with an unterminated string is refused before any field is read"
+    else
+        fail "an unterminated string should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# Sol, criterion 3: the duplicate-verdict refusal added in round 2 was ASSERTED
+# and never tested — replacing it with `if false` left the suite fully green.
+# The duplicate-verdict rows that existed belonged to the cross-model COMMENT
+# parser, a different mechanism. A guard covered only by another guard's tests
+# is untested.
+test_wrapper_blocks_round_1_on_duplicate_verdict_keys_in_an_entry() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md" \
+        "" "" '{"model":"r1","verdict":"CERTIFIED","findings_total":0},{"model":"r2","verdict":"NOT_CERTIFIED","verdict":"CERTIFIED","findings_total":0}'
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "an entry declaring verdict twice is refused, not resolved by position"
+    else
+        fail "duplicate verdict keys in an entry should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# ESCAPE-SMUGGLED DUPLICATES. A `base_sha` key IS `base_sha` — JSON
+# unescapes key names before they are keys, so any duplicate rule comparing
+# raw bytes sees two different keys where a parser sees one key twice.
+#
+# The live base is deliberately NOT moved: the plain key names it and would be
+# accepted on its own, so the escaped duplicate is the only thing that can
+# change the verdict. Move the base and the row blocks on the honest key and
+# proves nothing about escapes.
+test_wrapper_blocks_an_escape_smuggled_duplicate_key() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "\u0062ase_sha": "$(cat "$tmpdir/.fixture-base-moved-sha")",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "a duplicate key smuggled through a unicode escape is still a duplicate"
+    else
+        fail "an escaped duplicate key should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# Everything after the closing brace is not JSON, and a file that is not JSON
+# is not a certification — but a reader that only greps for fields never
+# notices there is a file left over.
+test_wrapper_blocks_a_clearance_with_trailing_garbage() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    raw_clearance "$tmpdir" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "review_file": ".reviews/some-review.md"
+}
+not json at all
+JSON
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "does not parse"; then
+        pass "an artifact with trailing non-JSON is refused"
+    else
+        fail "trailing garbage should block, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: an artifact predating #636 carries no base_sha and must not be grandfathered
+test_wrapper_blocks_clearance_without_base_sha() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Silence about the base is not an assertion about the base. Clearances are
+    # per-PR and written fresh each cycle, so nothing live is broken by refusing
+    # the old shape — and grandfathering it would leave the hole open forever
+    # behind an artifact that simply omits the field.
+    cat > "$tmpdir/.reviews/merge-clearance-123.json" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 2,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    # Asserting the ABSENCE wording specifically, not just "base_sha". Measured:
+    # with the absence branch neutered, CL_BASE_SHA is the empty string, which
+    # the mismatch check below then rejects anyway — and its message also says
+    # "base_sha", so a looser assertion stays GREEN through its own mutation and
+    # proves nothing. Same class as the #628 unreadable-base row.
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "declares no 'base_sha'"; then
+        pass "wrapper blocks a clearance carrying no base_sha at all"
+    else
+        fail "wrapper should block a clearance with no base_sha, got exit=$exit_code out=$out"
+    fi
+}
+
+# --- #563: the round>=2 rule blocks the case where the review was CLEANEST ---
+#
+# round >= 2 conflates "a dialogue happened" with "the review was adversarial",
+# and those come apart in exactly one case: both reviewers certify at round 1
+# with nothing to dispute. That happened on PR #562 — Sol zero at every
+# severity, Fable zero at every severity, both verifying the evidence against
+# primary sources. The only way to satisfy the gate from there was to re-invoke
+# both reviewers and ask them to re-verify nothing: ceremony that increments a
+# counter and buys no signal.
+#
+# Two independent clean certifications is STRONGER evidence than one two-round
+# dialogue, and the gate read it as weaker.
+#
+# The exemption is mechanical — it reads integers out of the artifact, never
+# prose — and it is deliberately narrow: two or more reviewers, every one of
+# them at findings_total 0.
+
+# Test: round 1 with two independently clean reviewers is allowed to merge
+test_wrapper_allows_round_1_two_clean_reviewers() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" \
+        ".reviews/some-review.md" "" "" "$(reviewers_with 2 0)"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    # Asserting the MERGE actually happened, not merely a zero exit: this is the
+    # one row in the #563 set that opens a path, so it has to prove the path
+    # reaches the end rather than that nothing errored on the way.
+    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "wrapper allows round=1 when two reviewers each certified with zero findings"
+    else
+        fail "wrapper should merge round=1 with two clean reviewers, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: one finding at any severity still demands the recheck round
+test_wrapper_blocks_round_1_when_a_reviewer_found_something() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # TWO clean reviewers PLUS one carrying a single finding. The two-clean part
+    # is deliberate and load-bearing: with only one clean and one dirty, the
+    # >= 2 floor blocks the row on its own and the finding-count guard is never
+    # exercised — measured, that shape stayed GREEN through its own mutation.
+    # Here the floor is satisfied, so the ONLY thing that can refuse this is the
+    # recorded finding. That is the RED the issue names: "a clearance with one
+    # P3 recorded must still demand round 2".
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" \
+        ".reviews/some-review.md" "" "" \
+        "{\"model\":\"r1\",\"findings_total\":0},{\"model\":\"r2\",\"findings_total\":0},{\"model\":\"r3\",\"findings_total\":1}"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -qi "round"; then
+        pass "wrapper blocks round=1 when any reviewer recorded a finding"
+    else
+        fail "wrapper should block round=1 with a non-zero findings_total, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: a single clean reviewer is not two, and does not earn the exemption
+test_wrapper_blocks_round_1_single_clean_reviewer() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" \
+        ".reviews/some-review.md" "" "" "$(reviewers_with 1 0)"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -qi "round"; then
+        pass "wrapper blocks round=1 with only one clean reviewer"
+    else
+        fail "wrapper should block round=1 with a single reviewer, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: the field being ABSENT is not the field being zero
+test_wrapper_blocks_round_1_when_findings_field_absent() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Two reviewers, both certified, NEITHER carrying findings_total — the exact
+    # shape of every clearance artifact written before #563. Silence about
+    # findings must never read as an assertion of zero findings, or the
+    # exemption retroactively applies to artifacts that never claimed it.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" \
+        ".reviews/some-review.md" "" "" \
+        "{\"model\":\"r1\",\"verdict\":\"CERTIFIED\"},{\"model\":\"r2\",\"verdict\":\"CERTIFIED\"}"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -qi "round"; then
+        pass "wrapper blocks round=1 when findings_total is absent, not zero"
+    else
+        fail "wrapper should block round=1 with no findings_total, got exit=$exit_code out=$out"
+    fi
+}
+
+# --- Round 1 of this PR's own review, P1: the counting was unscoped ---
+#
+# The first implementation grepped every `findings_total` in the artifact and
+# never checked the match belonged to a reviewer. Both rows below were EXECUTED
+# against it by the reviewer and both MERGED at exit 0. They are kept as
+# permanent rows rather than being folded into the ones above, because they fail
+# for a different reason than "wrong count": they fail because the thing being
+# counted was never the thing the contract names.
+
+# Test: stray findings_total keys outside any reviewer entry earn nothing
+test_wrapper_blocks_round_1_unscoped_findings_totals() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # ZERO reviewer entries. The two zeros sit at top level, where an
+    # occurrence-counting implementation happily finds them.
+    cat > "$tmpdir/.reviews/merge-clearance-123.json" <<JSON
+{
+  "pr_number": 123,
+  "status": "CERTIFIED",
+  "round": 1,
+  "sha": "$(cat "$tmpdir/.fixture-sha")",
+  "candidate_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_tree": "$(cat "$tmpdir/.fixture-tree")",
+  "base_sha": "$(cat "$tmpdir/.fixture-sha")",
+  "findings_total": 0,
+  "notes_findings_total": 0,
+  "review_file": ".reviews/some-review.md"
+}
+JSON
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "0 reviewer entries"; then
+        pass "wrapper blocks round=1 when the zeros belong to no reviewer"
+    else
+        fail "wrapper should block unscoped findings_total keys, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: a reviewer that reports nothing is not a reviewer that reports zero
+test_wrapper_blocks_round_1_partially_counted_reviewers() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Two clean reviewers satisfy the >= 2 floor on their own. The third
+    # declares no findings_total at all — so the artifact never claims that
+    # reviewer found nothing, and the gate must not infer it.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" \
+        ".reviews/some-review.md" "" "" \
+        "{\"model\":\"r1\",\"findings_total\":0},{\"model\":\"r2\",\"findings_total\":0},{\"model\":\"r3\",\"verdict\":\"CERTIFIED\"}"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "3 reviewer entries"; then
+        pass "wrapper blocks round=1 when one reviewer records no findings_total"
+    else
+        fail "wrapper should block a partially-counted reviewer set, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: zero findings without a certification is an abandoned review, not a clean one
+test_wrapper_blocks_round_1_clean_but_not_certified_reviewer() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # Round 1 P2. Zero findings is what the reviewer SAW; the verdict is what
+    # they CONCLUDED. A leg that timed out, or stopped early, or simply refused,
+    # can honestly report zero findings — and must not be counted as agreement.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 1 "$(cat "$tmpdir/.fixture-sha")" \
+        ".reviews/some-review.md" "" "" \
+        "{\"model\":\"r1\",\"verdict\":\"CERTIFIED\",\"findings_total\":0},{\"model\":\"r2\",\"verdict\":\"NOT_CERTIFIED\",\"findings_total\":0}"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -ne 0 ] && ! echo "$out" | grep -q "GH_MERGE_INVOKED" \
+        && echo "$out" | grep -q "2 reviewer entries"; then
+        pass "wrapper blocks round=1 when a zero-findings reviewer did not certify"
+    else
+        fail "wrapper should block a NOT_CERTIFIED zero-findings reviewer, got exit=$exit_code out=$out"
+    fi
+}
+
+# Test: round >= 2 is untouched by any of this
+test_wrapper_allows_round_2_without_findings_field() {
+    local tmpdir out exit_code
+    tmpdir=$(setup_wrapper_fixture)
+    # No reviewers array at all. #563 adds an alternative route past round >= 2;
+    # it must not add a REQUIREMENT to it. Every pre-#563 artifact looks like
+    # this one, and every one of them must still merge.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+    rm -rf "$tmpdir"
+    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED"; then
+        pass "wrapper still merges round>=2 with no findings_total present"
+    else
+        fail "wrapper should merge round=2 without the new field, got exit=$exit_code out=$out"
     fi
 }
 
@@ -802,7 +1856,11 @@ JSON
 test_wrapper_blocks_stale_clearance() {
     local tmpdir out exit_code
     tmpdir=$(setup_wrapper_fixture)
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "old-sha-999" ".reviews/some-review.md"
+    # A real 40-hex object name that is simply not the head. The old fixture used
+    # the placeholder "old-sha-999", which since the field grammar landed is
+    # refused as malformed BEFORE the staleness comparison is ever reached — so
+    # the row passed while testing a different refusal than the one it names.
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "9999999999999999999999999999999999999999" ".reviews/some-review.md"
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
@@ -1019,6 +2077,45 @@ test_wrapper_blocks_ci_neutral
 test_wrapper_blocks_missing_clearance
 test_wrapper_blocks_non_certified_status
 test_wrapper_blocks_round_1_only
+test_wrapper_blocks_moved_base_with_identical_tree
+test_wrapper_blocks_nested_base_sha_masking_a_stale_one
+test_wrapper_blocks_nested_candidate_tree_masking_a_stale_one
+test_wrapper_blocks_round_1_when_certified_appears_outside_the_verdict
+test_wrapper_blocks_round_1_when_a_nested_array_hides_a_dirty_reviewer
+test_wrapper_blocks_round_1_when_a_string_bracket_hides_a_dirty_reviewer
+test_wrapper_blocks_round_1_when_a_nested_reviewers_array_shadows_the_real_one
+test_wrapper_blocks_round_1_on_duplicate_reviewers_keys
+test_wrapper_allows_round_1_two_clean_reviewers_with_a_nested_array
+test_wrapper_blocks_round_1_on_duplicate_findings_total_in_an_entry
+test_wrapper_blocks_round_1_on_a_non_integer_findings_total
+test_wrapper_blocks_round_1_on_a_float_zero_findings_total
+test_wrapper_blocks_round_1_when_a_reviewers_entry_is_not_an_object
+test_wrapper_blocks_duplicate_status_keys
+test_wrapper_blocks_duplicate_base_sha_keys
+test_wrapper_blocks_tsv_injection_through_a_string_field
+test_wrapper_blocks_tsv_injection_forging_the_ancestry_binds
+test_wrapper_blocks_nul_normalising_a_string_field
+test_wrapper_blocks_nul_in_status_with_every_other_field_clean
+test_wrapper_refuses_a_malformed_object_name_at_the_parse
+test_wrapper_allows_a_review_file_path_containing_a_space
+test_wrapper_refuses_a_malformed_candidate_tree
+test_wrapper_refuses_a_malformed_base_tree
+test_wrapper_refuses_a_malformed_base_sha
+test_wrapper_blocks_duplicate_reviewers_key_with_a_non_array_value
+test_wrapper_blocks_a_clearance_whose_braces_do_not_balance
+test_wrapper_blocks_a_clearance_with_an_unterminated_string
+test_wrapper_blocks_round_1_on_duplicate_verdict_keys_in_an_entry
+test_wrapper_blocks_an_escape_smuggled_duplicate_key
+test_wrapper_blocks_a_clearance_with_trailing_garbage
+test_wrapper_blocks_clearance_without_base_sha
+test_wrapper_allows_round_1_two_clean_reviewers
+test_wrapper_blocks_round_1_when_a_reviewer_found_something
+test_wrapper_blocks_round_1_single_clean_reviewer
+test_wrapper_blocks_round_1_when_findings_field_absent
+test_wrapper_blocks_round_1_unscoped_findings_totals
+test_wrapper_blocks_round_1_partially_counted_reviewers
+test_wrapper_blocks_round_1_clean_but_not_certified_reviewer
+test_wrapper_allows_round_2_without_findings_field
 test_wrapper_blocks_stale_clearance
 test_wrapper_blocks_wrong_candidate_tree
 test_wrapper_blocks_moved_base


### PR DESCRIPTION
Closes #563. Closes #636.

## What ships

**#636 — ancestry.** A clearance named the base *tree* but not the base *commit*. A revert returns the base tree to its old value while the merge base advances, so a certification issued before the revert still matched after it. `base_sha` is now required and compared against the live base tip.

**#563 — the exemption.** Round 1 was refused in the one case where the review was cleanest. It is now exactly:

```
round == 1 is exempt IFF
  REVIEWER_COUNT >= 2  AND  CLEAN_COUNT == REVIEWER_COUNT  AND  DIRTY_COUNT == 0
```

**The artifact channel.** The clearance is written by the same agent that wants the merge, so the parse is a trust boundary. The hand-written JSON parser is replaced by `json.load` with duplicate-key and non-JSON-constant refusals; the tab-separated projection beneath it refuses the whole control-character class. Tab and newline forge rows — an artifact declaring no reviewers forged "2 reviewers, zero findings". NUL needs no separator at all: it is legal JSON, `json.load` decodes it, and **bash `$(...)` deletes it**, so a status carrying an embedded NUL reached the comparison as `CERTIFIED`. Per-field grammars on the object-name fields fail *closed* where an enumerated blacklist failed *open*.

## Every guard proven by breaking it

Round 9, both legs, each mutation marker-confirmed before any total was read:

| Mutation | Result |
|---|---|
| Reviewer floor to 1 | 123/1 |
| `CLEAN_COUNT == REVIEWER_COUNT` relaxed to `>= 1` | 120/4 |
| `base_sha` mismatch check off | 122/2 — the #636 revert case merged at exit 0 |
| `base_sha` absence branch off | 123/1 |
| `[ -s ]` review_file check off | 123/1 |
| Re-add a space-refusing path check | 123/1 — anti-re-add canary fired |
| Control-char refusal off | 122/2 |

Baselines 124/0 (`test-merge-gate.sh`) and 49/0 (`test-cross-model-clearance.sh`), before and after every mutation. Historical replay: all 35 round>=2 clearances still clear — the deletion moved only in the safe direction, verified not assumed.

## What was deleted rather than repaired

A `review_file` path guard added mid-review at round 6 is **gone**, both halves, plus five test rows. It could not carry a security property: nothing binds that file's content to this PR, so `README.md` satisfies the check, and refusing an out-of-repo path denies an artifact author nothing. Its four round-8 findings were all false refusals — a legal `-review.md`, a legitimate in-repo symlink, any invocation from a subdirectory — and **a false refusal in a merge gate is worse than dead code: it trains `--user-approved` overrides and erodes the gate it lives in.**

One positive row survives as the anti-re-add canary: a `review_file` path containing a space still merges. Every path grammar tried refused a space, so any re-added path check fails the suite. Round 9 proved it by re-adding one.

Real fix filed as #645 — bind the file's **content**, not its spelling.

## Residual, stated so it is read and not re-found

`review_file` remains satisfiable by any non-empty tracked file. That is in the code comment, in `known_limits`, and in #645. An out-of-repo `review_file` merges — but so does `README.md`, so the escape moves nothing.

## Review

Nine rounds, two independent models per round, private byte-identical working copies, guards proven by mutation. Rounds 1–5 drove the artifact channel to ground. Rounds 6–8 reviewed a guard that should never have been written; that is recorded honestly in `.reviews/563-636-round9.md` and filed as #644 and #617.

Round 9 was scope-bounded and introduced two required reviewer fields — `SHAPE` (should this code exist?) and per-finding `TARGET: IN-CARD | VOLUNTEERED`, where VOLUNTEERED admits only DELETE or FILE, never repair. Both legs returned **CERTIFIED, 0 findings, SHAPE: SOUND** — the first zero-finding round of the nine.

Full record: `.reviews/563-636-round9.md`.
