### PR TITLE
docs(roadmap): add a dated save point, and fix four stale or unscoped claims

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,9 +14,21 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > ### Release sequence
 >
-> `v1.99.0 — PR-B: the gate` → `v1.99.1 — the consumer-truth prose batch` → `v2.0.0`. Milestone membership on GitHub is authoritative; this line fixes only the order they ship in.
+> `v1.99.0 — PR-B: the gate` → `v1.99.1 — review-leg supervision` → `v1.99.2 — the consumer-truth prose batch` → `v2.0.0`. Milestone membership on GitHub is authoritative; this line fixes only the order they ship in. *(Corrected 2026-08-16: this said v1.99.1 was the prose batch. A supervision milestone was inserted ahead of it and the prose batch moved to v1.99.2.)*
 >
 > **v2.0.0's terminal gate is #545, not issue closure.** The major release is authorized when the maintainer has personally consumed the harness in another repo and it worked. Every other issue closing is necessary and not sufficient.
+>
+> ### Last save point — 2026-08-16, ~01:45
+>
+> Written so a cold session resumes without reading a transcript. Shipped to `main` tonight, in order — issue numbers only, because the tracker owns PR state (#482): **#617** (SHAPE and TARGET as required reviewer outputs), the **permission-allowlist** work (`gh pr comment` replaced by the fixed-argv wrapper `scripts/post-comment.sh` — the pattern would have authorized `--delete-last` on the merge gate's own clearance comments), and **#653** (the SHAPE routing card in `skills/sdlc/SKILL.md`).
+>
+> **Next action: #504's experiment — Fable drives milestone v1.99.2** (#579, #544, #537, #499), batched into ONE PR. Compare rounds, tokens and wall clock against the allowlist cycle's baseline: 4 rounds, 5 review legs, ~456k leg tokens, 43 minutes.
+>
+> **Open and unfinished:** `fix/585-operator-output-style` — 3 commits parked on a branch, never reviewed, #585 still open. **#622** — the post-mortem step has not run since v1.97.0; a 2.0 release with no end-of-release audit contradicts the harness's own rules, so it runs or the maintainer waives it explicitly.
+>
+> **Filed tonight:** #652 — `TESTING.md` reads as a suite registry but omits 54 of 80 CI suites.
+>
+> **The retro both reviewers gave, which the next session should act on rather than repeat:** tonight was valuable and over-expensive. The allowlist cycle's rounds 1–3 were the loop working; round 4 was self-inflicted — the driver never ran `tests/test-workflow-triggers.sh` and `tests/test-doc-consistency.sh` before committing a diff that touched `ci.yml`, so CI became the test phase. That pair takes **13.3 seconds** and would have saved **at least 4m47s** plus a dialogue round and two full clearance rebinds. The reviewers split on the fix: make it mechanical in the commit hook, or make it a mandatory step in the skill. Prose is the weaker option on tonight's own evidence — the output style was live in context and decayed anyway (#644).
 >
 > ### Standing rulings
 >
@@ -36,7 +48,9 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > **Also settled:** the second review leg is **conditional, with no npm-path carve-out** — nearly every meaningful PR here touches consumer-shipped `files`, so a path carve-out nullifies conditionality. The trigger is the **risk-tier field the scope cards already carry**: HIGH → leg 2 mandatory, low/medium → single leg. **This is not live yet** — `scripts/merge-pr.sh` still requires two clearances on every PR, and making the risk-tier trigger real is PR-B's work, tracked on #540 and #563. Until PR-B ships, the gate wins. The post-review confidence percentages are **cut** (#574): they did not discriminate — one leg certified at 100% and another at 96%, and a real P1 followed each.
 >
-> **Moved to backlog, premise changed:** #545 and #542's outside-repo consumption framing, and #504. The work is here, in this repo — not in sibling repos.
+> **Moved to backlog, premise changed:** #542's outside-repo consumption framing. The work is here, in this repo — not in sibling repos.
+>
+> *(Corrected 2026-08-16. This line also listed #545 and #504, and both are now live — it contradicted the terminal-gate paragraph four lines above it, which names #545 as the thing v2.0.0 waits on. **#545 is the v2.0.0 gate and is the maintainer's to run**, not backlog. **#504 was ruled on 2026-08-16**: do not swap the driver for the whole queue; instead Fable drives the single v1.99.2 milestone as a measured experiment, compared against the allowlist cycle's baseline of 4 rounds and ~15.5M session tokens. Ruling is on the issue.)*
 
 **Two rules, both enforced by [`tests/test-roadmap-integrity.sh`](tests/test-roadmap-integrity.sh)** — this section sat stale for two days in July 2026, so its freshness is now machine-checked rather than trusted:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,11 +28,13 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > **Filed tonight:** #652 — `TESTING.md` reads as a suite registry but omits 54 of 80 CI suites.
 >
-> **The retro both reviewers gave, which the next session should act on rather than repeat:** tonight was valuable and over-expensive. The allowlist cycle's rounds 1–3 were the loop working; round 4 was self-inflicted — the driver never ran `tests/test-workflow-triggers.sh` and `tests/test-doc-consistency.sh` before committing a diff that touched `ci.yml`, so CI became the test phase. That pair takes **13.3 seconds** and would have saved **at least 4m47s** plus a dialogue round and two full clearance rebinds. The reviewers split on the fix: make it mechanical in the commit hook, or make it a mandatory step in the skill. Prose is the weaker option on tonight's own evidence — the output style was live in context and decayed anyway (#644).
+> **The retro both reviewers gave, which the next session should act on rather than repeat:** tonight was valuable and over-expensive. The allowlist cycle's rounds 1–3 were the loop working; round 4 was self-inflicted — the driver never ran `tests/test-workflow-triggers.sh` and `tests/test-doc-consistency.sh` before committing a diff that touched `ci.yml`, so CI became the test phase. That pair takes **13.3 seconds** and would have saved **at least 4m47s** plus a dialogue round and two full clearance rebinds.
+>
+> **MAINTAINER RULING, 2026-08-16 — this does NOT become a rule, in the skill or in a hook.** Both reviewers proposed one (Sol: a mandatory step in `skills/sdlc/SKILL.md`; Fable: a lane in the commit hook, since prose decays). Both were declined, and no issue was filed. Verbatim: *"i wouldn't bake a one-off thing into the skill"* and *"that's not the worst to find the problem in CI if it's expensive to run — but if it's not, then we could have run that here."* **CI catching a forgotten test is an acceptable, cheap failure. The answer is targeted testing judgement — run the suites a diff plausibly breaks — not another permanent rule in a skill that is already long.** Do not re-open this without new evidence that it is recurring rather than a one-off.
 >
 > ### Standing rulings
 >
-> GitHub Issues is the store; this file routes to it. No gate redesign in PR-B. No new guard or tooling surface. One independently closable issue at a time.
+> GitHub Issues is the store; this file routes to it. No gate redesign in PR-B. No new guard or tooling surface. One independently closable issue at a time — *this scopes how Rung-1 work is picked, not how a ruled batch ships: prose batches go out under the 2026-08-10 batch ruling below, which shipped PR-A's six issues (#558, #557, #573, #574, #564, #556) as one PR while this line was already live. Clarified 2026-08-16.*
 
 > ### 2026-08-10 — RULED: batch the meta changes. Two PRs, prose first.
 >

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > ### Standing rulings
 >
-> GitHub Issues is the store; this file routes to it. No gate redesign in PR-B. No new guard or tooling surface. One independently closable issue at a time — *this scopes how Rung-1 work is picked, not how a ruled batch ships: prose batches go out under the 2026-08-10 batch ruling below, which shipped PR-A's six issues (#558, #557, #573, #574, #564, #556) as one PR while this line was already live. Clarified 2026-08-16.*
+> GitHub Issues is the store; this file routes to it. No gate redesign in PR-B. No new guard or tooling surface. One independently closable issue at a time — *this scopes how Rung-1 work is picked, not how a ruled batch ships; prose batches go out under the 2026-08-10 batch ruling below. That ruling is older than this line: PR-A shipped six issues (#558, #557, #573, #574, #564, #556) as ONE PR at 00:31 on 2026-08-11, and this sentence first landed 79 minutes later the same night. It was written after that batch, not against it. Clarified 2026-08-16.*
 
 > ### 2026-08-10 — RULED: batch the meta changes. Two PRs, prose first.
 >

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > ### Standing rulings
 >
-> GitHub Issues is the store; this file routes to it. No gate redesign in PR-B. No new guard or tooling surface. One independently closable issue at a time — *this scopes how Rung-1 work is picked, not how a ruled batch ships; prose batches go out under the 2026-08-10 batch ruling below. That ruling is older than this line: PR-A shipped six issues (#558, #557, #573, #574, #564, #556) as ONE PR at 00:31 on 2026-08-11, and this sentence first landed 79 minutes later the same night. It was written after that batch, not against it. Clarified 2026-08-16.*
+> GitHub Issues is the store; this file routes to it. No gate redesign in PR-B. No new guard or tooling surface. One independently closable issue at a time — *this scopes how Rung-1 work is picked, not how a ruled batch ships; prose batches go out under the 2026-08-10 batch ruling below. That ruling is older than this line: PR-A shipped six issues (#558, #557, #573, #574, #564, #556) as ONE PR at 00:31:52 on 2026-08-11 (`db2e018`), and this sentence first landed at 01:50:01 the same night (`0ad8351`). The chronology fixes only that this line is the later text; it says nothing about what its author intended toward the batch, and that question is not settled here. Clarified 2026-08-16.*
 
 > ### 2026-08-10 — RULED: batch the meta changes. Two PRs, prose first.
 >


### PR DESCRIPTION
## Why

The maintainer asked whether a new session can resume from `ROADMAP.md` alone. It could not — the file's shape was right, but three claims had gone stale and nothing recorded where tonight left off.

## What changed

1. **Release sequence corrected.** A supervision milestone was inserted ahead of the prose batch, so the sequence is now `v1.99.0 → v1.99.1 (review-leg supervision) → v1.99.2 (the consumer-truth prose batch) → v2.0.0`.
2. **"Moved to backlog, premise changed" no longer lists #545 and #504.** Both are live. The #545 entry directly contradicted the terminal-gate paragraph four lines above it, which names #545 as the thing v2.0.0 waits on. #504 was ruled the same day.
3. **A dated save point** naming what shipped, the next action, what is parked and unfinished, and the retro numbers — so the next session acts on them rather than rediscovering them.
4. **Line 35 scoped.** "One independently closable issue at a time" now says it governs how Rung-1 work is *picked*, not how a ruled batch *ships*, with the chronology stated exactly as `git log` supports it and no claim about authorial intent.
5. **The maintainer's ruling recorded**: no new rule making the pre-commit meta-suite run mandatory. CI catching a forgotten test is a cheap, acceptable failure.

## Review

Four rounds. The scoping note in item 4 carried three separate false claims in sequence — a wrong ordering, wrong arithmetic, and an intent claim chronology cannot support. **Every one was caught by the review leg; none by the author.**

Both legs clean on `940f703`: Sol CERTIFIED / SOUND / 100, Fable CERTIFIED / SOUND / 97, zero findings.

Issue numbers only, never PR numbers — `tests/test-roadmap-integrity.sh` enforces #482's rule that the tracker owns PR state, and it caught two violations in this change.

`roadmap-integrity` 5/0, `doc-consistency` 137/0, `workflow-triggers` 169/0.
