### PR TITLE
fix(roadmap): a cold session could not resume from this file — three defects

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,9 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > Written so a cold session resumes without reading a transcript. Shipped to `main` tonight, in order — issue numbers only, because the tracker owns PR state (#482): **#617** (SHAPE and TARGET as required reviewer outputs), the **permission-allowlist** work (`gh pr comment` replaced by the fixed-argv wrapper `scripts/post-comment.sh` — the pattern would have authorized `--delete-last` on the merge gate's own clearance comments), and **#653** (the SHAPE routing card in `skills/sdlc/SKILL.md`).
 >
-> **Next action: #504's experiment — Fable drives milestone v1.99.2** (#579, #544, #537, #499), batched into ONE PR. Compare rounds, tokens and wall clock against the allowlist cycle's baseline: 4 rounds, 5 review legs, ~456k leg tokens, 43 minutes.
+> **Next action: #504's experiment — Fable drives milestone v1.99.2** (#579, #544, #499), batched into ONE PR. Compare rounds, tokens and wall clock against the allowlist cycle's baseline: 4 rounds, 5 review legs, ~456k leg tokens, 43 minutes. *(Corrected 2026-08-16: this listed #537 too. #537 is a capability detector plus tests — code in a batch premised on prose, which both re-adds the test surface the batch removes and contaminates the measurement. Moved to v1.99.1; ruling on #504.)*
+>
+> **This work merges before v1.99.0 and v1.99.1, deliberately, and that is safe** — `release.yml` triggers on a tag push, so merging publishes nothing. **It is not free at tag time:** v1.99.0 and v1.99.1 are cut from a `main` that already carries this content, so whoever tags them states which content is present ahead of its milestone. Rung 1's item 3 (#521) stays open and is deliberately deferred — repairing the review surface mid-experiment would change what the experiment measures. Both rulings are on #593 and #504.
 >
 > **Open and unfinished:** `fix/585-operator-output-style` — 3 commits parked on a branch, never reviewed, #585 still open. **#622** — the post-mortem step has not run since v1.97.0; a 2.0 release with no end-of-release audit contradicts the harness's own rules, so it runs or the maintainer waives it explicitly.
 >


### PR DESCRIPTION
## Why

#655 added a save point so a cold session could resume from `ROADMAP.md` alone. It was certified 100/97 with zero findings — **because the review scope was the diff.**

The maintainer then asked both legs the narrower question directly: *can a cold session actually resume from this file?* Both said **no**, and between them found three defects. All three live in the gap between this file and the tracker it routes to, which a diff review cannot see.

## The three defects

| # | Found by | Defect |
|---|---|---|
| 1 | Sol, P1 | v1.99.2 was listed as containing **#537**, which requires a capability detector **and tests**. The milestone is *the consumer-truth prose batch* and the 2026-08-10 ruling justifies it on exactly that basis. Code in that batch re-adds the test surface the batch exists to remove — and contaminates #504's measurement, since a driver experiment compared against a prose baseline measures content, not driver. |
| 2 | Sol, P1 (partially accepted) | v1.99.2's work merges **before** v1.99.0 and v1.99.1 ship. Sol's premise that this publishes early is false — `release.yml` triggers on a tag push, verified in the workflow — so the routing stands. The surviving residue: the later tags are cut from a `main` that already carries this content. |
| 3 | Fable | `DO THIS NOW` sends a cold reader to #593 Rung 1's first open issue, which is **#521** (item 3). The save point sends it to **#504** (item 5). |

## Dispositions

- **#537 moved to `v1.99.1 — review-leg supervision`.** Batch is now #579, #544, #499. — [#504](https://github.com/BaseInfinity/claude-sdlc-harness/issues/504#issuecomment-5308932024)
- **Tag-order duty written down**, not routed around. Renumbering the milestones was considered and rejected: every standing ruling references them by name.
- **#521 stays open and is deliberately deferred** — #504's own experiment design excludes repairing it mid-comparison. Nothing said so; now it does. — [#593](https://github.com/BaseInfinity/claude-sdlc-harness/issues/593#issuecomment-5308931957)

This file records the *effect* of those rulings. It does not decide anything.

## Review

Two rounds. Round 1 was the ruling itself: Fable ruled all three, Sol certified the ruling at 94% with zero findings after having its own P1a rejected on primary evidence. Round 2 is this diff — Sol CERTIFIED 95, Fable CERTIFIED 96, zero findings each.

`roadmap-integrity` 5/0, `doc-consistency` 137/0.
