### PR TITLE
docs(readme): say what has actually been exercised, and move the rest out

### DIFF
--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -250,6 +250,42 @@ Watch the headless surface if you've automated `claude -p` calls in your project
 
 The wizard does not enforce setup lane selection — it documents the recommended default per change shape. Whatever ships is your call.
 
+## Model Selection — The Evidence
+
+Moved here from `README.md` so that section stays short. **Read the honesty
+note there first:** Setup A is the only lane with cycle data from this repo.
+The research below is third-party field data about model behavior in general.
+It is the reasoning behind the lane assignments; it is not a measurement of
+this harness running on any lane other than A.
+
+### Why Opus 4.6 was the flagship, and why that changed
+
+Two weeks of in-the-wild data after Opus 4.8's launch (2026-05-28) showed a clear pattern that first made Opus 4.6 the wizard's flagship over Anthropic's own "latest" model:
+
+- **[Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench)** — 4.8 finished last vs 4.7 and GPT-5.5; documented "Max reasoning is not the best reasoning effort"; falls for scam suppliers 30× more frequently
+- **[AI Weekly: 900K cache tokens per turn](https://aiweekly.co/alerts/claude-opus-48-thinking-burns-900k-tokens-per-turn)** — 40-60× jump vs 4.7 at HIGH effort. Burns Max 5-hour limits 2-3× faster
+- **[Tech.yahoo review](https://tech.yahoo.com/ai/claude/articles/claude-opus-4-8-review-130106963.html)** — explicit: "Anthropic deliberately made Opus's new tokenizer less efficient"; "a single coding prompt drained our entire token quota"
+- **Active GitHub regressions** — false-greens ([#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), 46K tokens for simple coding turn ([#64153](https://github.com/anthropics/claude-code/issues/64153)), dropped constraints during execution ([#65932](https://github.com/anthropics/claude-code/issues/65932)), fabricated identifiers in parallel tool batches
+- **[Paweł Huryn's 4.7 guide](https://www.productcompass.pm/p/claude-opus-4-7-guide)** — "most complaints about 4.7 feeling slow stem from people reflexively using max"
+- **[BSWEN effort decision guide](https://docs.bswen.com/blog/2026-04-19-claude-code-effort-level-decision-guide/)** — "Max on Opus causes overthinking on routine stuff. xHigh is the sweet spot for autonomous work"
+- **r/Claudeopus field reports** — one maintainer's literal A/B: "12 hours with 4.8 zero deliverables; plugged in 4.6, spec written + 133 tests green in one session." Top comment: "4.6 had the best overall balance at max"
+
+That research still stands as the reason **Sonnet 5 (not Opus 4.6, not Opus 4.8) is Setup B's driver** — Sonnet 5 doesn't have Opus 4.8's overthinking problem, and generally uses less quota for comparable-scope work. **Note what kind of evidence that is:** third-party field reports about model behavior in general, not a measurement of this harness running on Setup B. Setup A is the only lane behind which there is cycle data from this repo, and the lane tables above label Setup B unverified for exactly that reason. The two statements are consistent — the research picks Sonnet 5 *over other Setup B candidates*; it says nothing about Setup B versus Setup A. Opus 4.6/4.8 remain reachable as an explicit escalation/stability pin (see the lane tables above) for anyone who's tuned a workflow to their specific behavior, but neither is a lane driver anymore.
+
+**Why Opus 5 became the default (2026-07-24), on top of that history.** Opus 5 launched today at the same price as Opus 4.8, positioned by Anthropic as "close to Fable 5 intelligence at half the price," with documented self-verification improvements. Every capability claim behind this is Anthropic's own launch-day material — zero field data exists yet, the exact evidence class the wizard's own process treats with skepticism (see this document's trial-flagged framing). The wizard maintainer chose to adopt it as default anyway, judging the risk acceptable since Codex still gates every task and reverting is one settings change. Sonnet 5 remains the wizard's evidence-backed pick for lower-stakes work — Setup B, not deprecated.
+
+4.6 remains Anthropic-supported until **≥ Feb 5, 2027** per the [official deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations).
+
+**Effort is model-aware, not blanket `max`.** Opus 5: `high` default for Setup A, `medium` for routine web/CRUD (changed 2026-08-02); `xhigh` is an escalation trigger for difficult/long-running work, not the default — effort tiers are static per session, but Opus 5 has documented adaptive reasoning *within* a fixed tier. Sonnet 5: `medium` default (CodeRabbit-tested), escalate `/effort high` → `xhigh` for hard tasks. Opus 4.8: `xhigh` (its own `max` overthinks). Opus 4.6: `max` (its one `xhigh`-less sweet spot). Set per-session with `/effort`, not a shell-rc or settings env var — persisting effort that way silently overrides a later `/effort` change after you switch models (see `SDLC.md`'s Lessons Learned for a real incident this caused). Also check for a stale `ANTHROPIC_DEFAULT_OPUS_MODEL` env var in your shell rc files — it silently overrides `/model opus` picker choices. OpenAI/Codex reviewer: `high` default (2026-08-01; cost and review-noise, not capability) — escalate to `xhigh` for unusually risky PRs, `max`/Pro above that (see the Final Review Policy above).
+
+### Reading Setup A precisely
+
+Clarified 2026-07-13, updated 2026-07-24 for the Opus 5 swap — these exact points kept getting re-confused; each rule states its why:
+
+- **Effort starts at `high`, not `xhigh`** (changed 2026-08-02). Opus 5's own documented default is `high` for general use. Anthropic recommends "extra" (`xhigh`) specifically for difficult and long-running asynchronous work — treat that as an escalation trigger, not the standing default, and drop to `medium` for routine web/CRUD.
+- **Model escalation swaps the driver, not the tier.** After 2 failed attempts, LOW confidence, or on high-stakes changes with Setup A already exhausted, a pinned Opus 4.8 (`claude-opus-4-8`) takes over as driver for a genuinely independent second pass — Opus-5-driver plus an Opus-5 advisor fallback would otherwise be a same-family self-check. Why a swap and not more effort: the lane's policy treats repeated failure as a sign the *approach* needs different eyes, not deeper reasoning on the same track.
+- **Advisor failure has a fallback, not a shrug.** Fable 5 advises via `advisorModel: "fable"` — disabled by an Anthropic rollout on 2026-07-24, observed working again on 2026-08-16. Availability is a dated observation, so establish it by calling the tool. On a real failure, spawn a Fable subagent at `high` as the fallback reviewer immediately, exactly as the `/sdlc` skill prescribes. Why: the advisor's job is catching wrong approaches *before* they're built, so a transport failure changes how the advice is obtained — not whether the check happens.
+
 ## See Also
 
 - [`CLAUDE_CODE_SDLC_WIZARD.md`](CLAUDE_CODE_SDLC_WIZARD.md) — Full wizard doc, including Stability tier opt-in for the wider model choice

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1215,7 +1215,7 @@ Set effort per-session with `/effort` (planner `xhigh`, driver `medium`, escalat
 
 ### Latest tier — Opus 4.8 (pinned escalation model, #395)
 
-The wizard's default is **Opus 5** (Setup A, trial as of 2026-07-24 — see "Choosing Your Model" in [README.md](../README.md) for the full evidence, including the accepted-risk framing). **Opus 4.8**, pinned explicitly (`claude-opus-4-8`), is the same-family-check escalation model: reach for it when the default driver stalls on architecture, a stuck bug, or anything needing a genuinely independent second pass — not as a daily driver. It ships SWE-Bench Pro / Terminal-Bench 2.1 gains, dynamic-workflows, and parallel-subagent-swarm features 4.6 doesn't have.
+The wizard's default is **Opus 5** (Setup A, trial as of 2026-07-24 — see "Model Selection — The Evidence" in [AI_SETUP_LANES.md](../AI_SETUP_LANES.md) for the full evidence, including the accepted-risk framing). **Opus 4.8**, pinned explicitly (`claude-opus-4-8`), is the same-family-check escalation model: reach for it when the default driver stalls on architecture, a stuck bug, or anything needing a genuinely independent second pass — not as a daily driver. It ships SWE-Bench Pro / Terminal-Bench 2.1 gains, dynamic-workflows, and parallel-subagent-swarm features 4.6 doesn't have.
 
 **When Opus 4.8 is the right call:**
 - The driver is stuck (2+ failed attempts) and you want a fresh, deeper-reasoning pass

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ Reviewer effort is `high` (changed from `xhigh` 2026-08-01, for cost and review-
 The wizard ships a **default recommendation**, not a mandate. Swap to any Claude
 model at any time — `/model` per session, or pin in `.claude/settings.json`.
 
-**Default: Opus 5 at `high` effort, `medium` for routine web/CRUD** (Setup A).
+**Default: Opus 5 at `high` effort for complex projects, `medium` for routine
+web/CRUD** (Setup A).
 **Sonnet 5 at `medium` effort** (Setup B) for simple or one-off work.
 
 **What has actually been exercised on this harness:** Setup A only — Opus 5

--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ Setup D's whole point: **the discipline of knowing when NOT to use discipline.**
 ### Going deeper
 
 [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) carries the rest, so this section stays
-short: the per-model effort table, how to read Setup A precisely, the evidence
-behind the 4.6 / 4.8 / Sonnet 5 positions, and
+short: the per-model effort table,
+[how to read Setup A precisely](AI_SETUP_LANES.md), the evidence behind the
+4.6 / 4.8 / Sonnet 5 positions, and
 [how billing works](AI_SETUP_LANES.md#how-billing-works--1m-context-max-plan-and-the-june-15-split)
 (1M context is GA at standard pricing; the June 15, 2026 split moved *headless*
 surfaces off Max, interactive Claude Code stays on it).

--- a/README.md
+++ b/README.md
@@ -151,13 +151,21 @@ model at any time — `/model` per session, or pin in `.claude/settings.json`.
 web/CRUD** (Setup A).
 **Sonnet 5 at `medium` effort** (Setup B) for simple or one-off work.
 
-**What has actually been exercised on this harness:** Setup A only — Opus 5
-driving, Fable 5 advising, GPT-5.6 Sol gating. That is the lane every cycle in
-this repo has run on, and it is the only lane behind which there is cycle data
-from this repo. The other lanes and the `claude-opus-4-6` / `claude-opus-4-8`
-pins are supported and reachable, but **no one has run a cycle of this harness
-on them.** `AI_SETUP_LANES.md` labels them unverified for that reason. Treat
-their entries below as configuration that should work, not as measured results.
+**What has actually been exercised on this harness.** Current Setup A — Opus 5
+driving, Fable 5 advising, GPT-5.6 Sol gating — is what recent cycles run on,
+and it is the configuration behind the most recent evidence.
+
+It is not the only one this repo has ever used, and the honest version says so.
+This repo dates to January 2026, well before Opus 5 existed. **Opus 4.6 was the
+wizard's own recommended flagship default from v1.80.0 (June 2026)**, so real
+cycles ran on it — see `CHANGELOG.md`. What has *not* been exercised is 4.6 (or
+4.8) paired with the **current** review setup, where Fable is the design
+authority and Sol is the adversarial gate. Those pairings are supported and
+reachable, never measured.
+
+Treat the lane entries below as configuration that should work. Only current
+Setup A carries recent cycle data, and `AI_SETUP_LANES.md` labels the rest
+unverified for that reason.
 
 ### Switch any time
 

--- a/README.md
+++ b/README.md
@@ -144,32 +144,24 @@ Reviewer effort is `high` (changed from `xhigh` 2026-08-01, for cost and review-
 
 ## Choosing Your Model
 
-The wizard ships a **default recommendation**, not a mandate. You can swap to any Claude model — newer, older, or sibling tier — at any time. `/model` per session, or pin in `.claude/settings.json`.
+The wizard ships a **default recommendation**, not a mandate. Swap to any Claude
+model at any time — `/model` per session, or pin in `.claude/settings.json`.
 
-**Default: Opus 5 at `high` effort for complex projects, `medium` for routine web/CRUD** (Setup A in `AI_SETUP_LANES.md`; effort default changed 2026-08-02). Escalate to `xhigh` for genuinely hard or long-running agentic runs — Anthropic's own framing for that tier — but not as the standing default: their Opus 5 prompting guide advises using lower effort liberally wherever quality holds, and higher effort increases elaboration and self-directed scope. **Sonnet 5 at `medium` effort** (Setup B) remains the evidence-backed pick for simple/one-off work.
+**Default: Opus 5 at `high` effort, `medium` for routine web/CRUD** (Setup A).
+**Sonnet 5 at `medium` effort** (Setup B) for simple or one-off work.
 
-### Why Opus 4.6 was the flagship, and why that changed
-
-Two weeks of in-the-wild data after Opus 4.8's launch (2026-05-28) showed a clear pattern that first made Opus 4.6 the wizard's flagship over Anthropic's own "latest" model:
-
-- **[Andon Labs Vending-Bench](https://andonlabs.com/blog/opus-4-8-vending-bench)** — 4.8 finished last vs 4.7 and GPT-5.5; documented "Max reasoning is not the best reasoning effort"; falls for scam suppliers 30× more frequently
-- **[AI Weekly: 900K cache tokens per turn](https://aiweekly.co/alerts/claude-opus-48-thinking-burns-900k-tokens-per-turn)** — 40-60× jump vs 4.7 at HIGH effort. Burns Max 5-hour limits 2-3× faster
-- **[Tech.yahoo review](https://tech.yahoo.com/ai/claude/articles/claude-opus-4-8-review-130106963.html)** — explicit: "Anthropic deliberately made Opus's new tokenizer less efficient"; "a single coding prompt drained our entire token quota"
-- **Active GitHub regressions** — false-greens ([#63861](https://github.com/anthropics/claude-code/issues/63861)), 2-3× token burn ([#64961](https://github.com/anthropics/claude-code/issues/64961)), 46K tokens for simple coding turn ([#64153](https://github.com/anthropics/claude-code/issues/64153)), dropped constraints during execution ([#65932](https://github.com/anthropics/claude-code/issues/65932)), fabricated identifiers in parallel tool batches
-- **[Paweł Huryn's 4.7 guide](https://www.productcompass.pm/p/claude-opus-4-7-guide)** — "most complaints about 4.7 feeling slow stem from people reflexively using max"
-- **[BSWEN effort decision guide](https://docs.bswen.com/blog/2026-04-19-claude-code-effort-level-decision-guide/)** — "Max on Opus causes overthinking on routine stuff. xHigh is the sweet spot for autonomous work"
-- **r/Claudeopus field reports** — one maintainer's literal A/B: "12 hours with 4.8 zero deliverables; plugged in 4.6, spec written + 133 tests green in one session." Top comment: "4.6 had the best overall balance at max"
-
-That research still stands as the reason **Sonnet 5 (not Opus 4.6, not Opus 4.8) is Setup B's driver** — Sonnet 5 doesn't have Opus 4.8's overthinking problem, and generally uses less quota for comparable-scope work. **Note what kind of evidence that is:** third-party field reports about model behavior in general, not a measurement of this harness running on Setup B. Setup A is the only lane behind which there is cycle data from this repo, and `AI_SETUP_LANES.md` labels Setup B unverified for exactly that reason. The two statements are consistent — the research picks Sonnet 5 *over other Setup B candidates*; it says nothing about Setup B versus Setup A. Opus 4.6/4.8 remain reachable as an explicit escalation/stability pin (see `AI_SETUP_LANES.md`) for anyone who's tuned a workflow to their specific behavior, but neither is a lane driver anymore.
-
-**Why Opus 5 became the default (2026-07-24), on top of that history.** Opus 5 launched today at the same price as Opus 4.8, positioned by Anthropic as "close to Fable 5 intelligence at half the price," with documented self-verification improvements. Every capability claim behind this is Anthropic's own launch-day material — zero field data exists yet, the exact evidence class the wizard's own process treats with skepticism (see `AI_SETUP_LANES.md`'s trial-flagged framing). The wizard maintainer chose to adopt it as default anyway, judging the risk acceptable since Codex still gates every task and reverting is one settings change. Sonnet 5 remains the wizard's evidence-backed pick for lower-stakes work — Setup B, not deprecated.
-
-4.6 remains Anthropic-supported until **≥ Feb 5, 2027** per the [official deprecation page](https://platform.claude.com/docs/en/about-claude/model-deprecations).
+**What has actually been exercised on this harness:** Setup A only — Opus 5
+driving, Fable 5 advising, GPT-5.6 Sol gating. That is the lane every cycle in
+this repo has run on, and it is the only lane behind which there is cycle data
+from this repo. The other lanes and the `claude-opus-4-6` / `claude-opus-4-8`
+pins are supported and reachable, but **no one has run a cycle of this harness
+on them.** `AI_SETUP_LANES.md` labels them unverified for that reason. Treat
+their entries below as configuration that should work, not as measured results.
 
 ### Switch any time
 
 ```bash
-/model opus               # wizard's default (Setup A) — Opus 5, requires CC v2.1.219+
+/model opus                # wizard's default (Setup A) — Opus 5, requires CC v2.1.219+
 /model sonnet              # Simple/one-off lane (Setup B) — native 1M context, lower cost
 /model opusplan            # Opus 5 plans (Shift+Tab), Sonnet executes — both Max-bundled (Setup C)
 /model claude-opus-4-8     # pin explicitly for Opus 4.8's field-proven behavior instead of Opus 5
@@ -182,7 +174,9 @@ Or pin in `.claude/settings.json`:
 { "model": "opus", "advisorModel": "fable", "effortLevel": "high" }
 ```
 
-**Effort is model-aware, not blanket `max`.** Opus 5: `high` default for Setup A, `medium` for routine web/CRUD (changed 2026-08-02); `xhigh` is an escalation trigger for difficult/long-running work, not the default — effort tiers are static per session, but Opus 5 has documented adaptive reasoning *within* a fixed tier. Sonnet 5: `medium` default (CodeRabbit-tested), escalate `/effort high` → `xhigh` for hard tasks. Opus 4.8: `xhigh` (its own `max` overthinks). Opus 4.6: `max` (its one `xhigh`-less sweet spot). Set per-session with `/effort`, not a shell-rc or settings env var — persisting effort that way silently overrides a later `/effort` change after you switch models (see `SDLC.md`'s Lessons Learned for a real incident this caused). Also check for a stale `ANTHROPIC_DEFAULT_OPUS_MODEL` env var in your shell rc files — it silently overrides `/model opus` picker choices. OpenAI/Codex reviewer: `high` default (2026-08-01; cost and review-noise, not capability) — escalate to `xhigh` for unusually risky PRs, `max`/Pro above that (see `AI_SETUP_LANES.md`'s Final Review Policy).
+Set effort per session with `/effort`, not a shell-rc or settings env var —
+persisting it that way silently overrides a later `/effort` change once you
+switch models.
 
 ### Four Setup Lanes
 
@@ -197,15 +191,14 @@ The wizard defines four AI coding setups in [`AI_SETUP_LANES.md`](AI_SETUP_LANES
 
 Setup D's whole point: **the discipline of knowing when NOT to use discipline.** When blast radius is low and you just need fast cheap hands, skip the SDLC overhead.
 
-### Reading Setup A precisely
+### Going deeper
 
-Clarified 2026-07-13, updated 2026-07-24 for the Opus 5 swap — these exact points kept getting re-confused; each rule states its why:
-
-- **Effort starts at `high`, not `xhigh`** (changed 2026-08-02). Opus 5's own documented default is `high` for general use. Anthropic recommends "extra" (`xhigh`) specifically for difficult and long-running asynchronous work — treat that as an escalation trigger, not the standing default, and drop to `medium` for routine web/CRUD.
-- **Model escalation swaps the driver, not the tier.** After 2 failed attempts, LOW confidence, or on high-stakes changes with Setup A already exhausted, a pinned Opus 4.8 (`claude-opus-4-8`) takes over as driver for a genuinely independent second pass — Opus-5-driver plus an Opus-5 advisor fallback would otherwise be a same-family self-check. Why a swap and not more effort: the lane's policy treats repeated failure as a sign the *approach* needs different eyes, not deeper reasoning on the same track.
-- **Advisor failure has a fallback, not a shrug.** Fable 5 advises via `advisorModel: "fable"` — disabled by an Anthropic rollout on 2026-07-24, observed working again on 2026-08-16. Availability is a dated observation, so establish it by calling the tool. On a real failure, spawn a Fable subagent at `high` as the fallback reviewer immediately, exactly as the `/sdlc` skill prescribes. Why: the advisor's job is catching wrong approaches *before* they're built, so a transport failure changes how the advice is obtained — not whether the check happens.
-
-**A note on `[1m]` and billing.** Sonnet 5 always runs at its native 1M context — no `[1m]` suffix needed, no separate billing tier. For Opus, the `[1m]` suffix is the 1M-context alias; as of [March 2026](https://claude.com/blog/1m-context-ga), 1M context is GA at standard pricing — **no long-context surcharge, no premium tier, no API-only restriction.** Interactive Claude Code sessions on Max / Team / Enterprise plans include 1M context automatically. (Pro users need "Enable usage credits" turned on once.) The [June 15, 2026 billing split](https://codersera.com/blog/anthropic-june-2026-billing-change-claude-code/) moved *headless* surfaces — `claude -p`, Agent SDK, GitHub Actions, third-party apps — off the Max subscription onto a separate metered credit pool. Interactive Claude Code in your terminal stays on Max. Full details in [`AI_SETUP_LANES.md` § How Billing Works](AI_SETUP_LANES.md#how-billing-works--1m-context-max-plan-and-the-june-15-split).
+[`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) carries the rest, so this section stays
+short: the per-model effort table, how to read Setup A precisely, the evidence
+behind the 4.6 / 4.8 / Sonnet 5 positions, and
+[how billing works](AI_SETUP_LANES.md#how-billing-works--1m-context-max-plan-and-the-june-15-split)
+(1M context is GA at standard pricing; the June 15, 2026 split moved *headless*
+surfaces off Max, interactive Claude Code stays on it).
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -152,20 +152,11 @@ web/CRUD** (Setup A).
 **Sonnet 5 at `medium` effort** (Setup B) for simple or one-off work.
 
 **What has actually been exercised on this harness.** Current Setup A — Opus 5
-driving, Fable 5 advising, GPT-5.6 Sol gating — is what recent cycles run on,
-and it is the configuration behind the most recent evidence.
-
-It is not the only one this repo has ever used, and the honest version says so.
-This repo dates to January 2026, well before Opus 5 existed. **Opus 4.6 was the
-wizard's own recommended flagship default from v1.80.0 (June 2026)**, so real
-cycles ran on it — see `CHANGELOG.md`. What has *not* been exercised is 4.6 (or
-4.8) paired with the **current** review setup, where Fable is the design
-authority and Sol is the adversarial gate. Those pairings are supported and
-reachable, never measured.
-
-Treat the lane entries below as configuration that should work. Only current
-Setup A carries recent cycle data, and `AI_SETUP_LANES.md` labels the rest
-unverified for that reason.
+driving, Fable 5 advising, GPT-5.6 Sol gating — is what recent cycles run on.
+Earlier defaults existed (Opus 4.6, June 2026 — see `CHANGELOG.md`) but predate
+the current review setup, so none of that data transfers. The other lanes and
+the `claude-opus-4-6` / `claude-opus-4-8` pins are configuration that should
+work, not measured results.
 
 ### Switch any time
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1707,9 +1707,16 @@ test_readme_reviewer_is_gpt56() {
     # (Re-pinned 2026-08-16 by #544's frontier-model banner, which shifted every
     # line below it by 4. Position pins again, not content — see #659.)
     bad="$bad$(_check_line_has_and_lacks "$F" 130 "5\.6,Sol,Terra" "5\.5" "5\.4")"
-    for n in 193 194 195; do
-        bad="$bad$(_check_line_has_and_lacks "$F" "$n" "5\.6,Sol" "5\.5")"
-    done
+    # Every OTHER line naming a GPT-5.x reviewer must name 5.6, by CONTENT.
+    # This replaced position pins on lines 193-195 when the model-selection
+    # research moved to AI_SETUP_LANES.md (#659 asked for exactly this: the
+    # pins had already been re-anchored once and broke again on the move).
+    # README carries no historical GPT-5.5 citation — the Vending-Bench one
+    # moved out with the research, and its own guard followed it there.
+    local stale
+    stale="$(grep -n 'GPT-5\.' "$F" | grep -v 'GPT-5\.6' || true)"
+    [ -n "$stale" ] && bad="$bad$(printf ' stale-GPT-line:%s' "$(printf '%s' "$stale" | cut -d: -f1 | tr '\n' ',')")"
+    grep -q 'GPT-5\.6 Sol' "$F" || bad="$bad README.md(no-sol-reference-at-all)"
     if [ -z "$bad" ]; then
         pass "README.md: all reviewer-model lines reference GPT-5.6 Sol/Terra, none reference stale GPT-5.5/5.4"
     else
@@ -1717,16 +1724,23 @@ test_readme_reviewer_is_gpt56() {
     fi
 }
 
-# L155 is a historical eval citation (Andon Labs Vending-Bench actually used
-# GPT-5.5 at the time) — must NOT be rewritten, or the citation becomes
-# factually wrong about what model that benchmark run used.
-test_readme_vending_bench_citation_untouched() {
-    local F="$REPO_ROOT/README.md"
-    if [ ! -f "$F" ]; then fail "README.md not found"; return; fi
-    if sed -n '155p' "$F" | grep -q "GPT-5\.5"; then
-        pass "README.md L155 vending-bench citation still names GPT-5.5 (historical, untouched)"
+# The Vending-Bench line is a historical eval citation (Andon Labs actually ran
+# GPT-5.5 at the time) — it must NOT be rewritten to 5.6, or the citation
+# becomes factually wrong about what model that benchmark run used. It lived in
+# README until the model-selection research moved to AI_SETUP_LANES.md; the
+# guard follows the content. Located by CONTENT, not line number, so moving it
+# again cannot silently disable this check.
+test_vending_bench_citation_untouched() {
+    local F="$REPO_ROOT/AI_SETUP_LANES.md"
+    if [ ! -f "$F" ]; then fail "AI_SETUP_LANES.md not found"; return; fi
+    local line
+    line="$(grep -n 'Vending-Bench' "$F" | head -1)"
+    if [ -z "$line" ]; then
+        fail "Vending-Bench citation not found in AI_SETUP_LANES.md — the historical citation was deleted or moved again"
+    elif printf '%s' "$line" | grep -q "GPT-5\.5"; then
+        pass "Vending-Bench citation still names GPT-5.5 (historical, untouched)"
     else
-        fail "README.md L155 vending-bench citation no longer names GPT-5.5 — historical citation was rewritten"
+        fail "Vending-Bench citation no longer names GPT-5.5 — historical citation was rewritten"
     fi
 }
 
@@ -1826,7 +1840,7 @@ test_claude_md_reviewer_is_gpt56() {
 
 test_ai_setup_lanes_reviewer_is_gpt56
 test_readme_reviewer_is_gpt56
-test_readme_vending_bench_citation_untouched
+test_vending_bench_citation_untouched
 test_wizard_doc_reviewer_is_gpt56
 test_wizard_doc_e2e_audit_citation_untouched
 test_skill_files_reviewer_is_gpt56
@@ -1876,8 +1890,11 @@ test_sonnet5_default_effort_is_medium() {
         || bad="$bad AI_SETUP_LANES.md(ladder)"
     grep -q 'Sonnet 5 at `medium` effort' "$REPO_ROOT/README.md" \
         || bad="$bad README.md(default-line)"
-    grep -q 'Sonnet 5: `medium` default' "$REPO_ROOT/README.md" \
-        || bad="$bad README.md(effort-line)"
+    # The per-model effort wall moved from README to AI_SETUP_LANES.md with the
+    # rest of the model-selection research; the assertion followed it. README
+    # still states the default in its own idiom (default-line, above).
+    grep -q 'Sonnet 5: `medium` default' "$REPO_ROOT/AI_SETUP_LANES.md" \
+        || bad="$bad AI_SETUP_LANES.md(effort-wall)"
     grep -q 'Sonnet 5: `medium` default' "$REPO_ROOT/SDLC.md" \
         || bad="$bad SDLC.md"
     grep -q 'Sonnet 5 `medium`' "$REPO_ROOT/skills/sdlc/SKILL.md" \
@@ -1952,10 +1969,14 @@ test_setup_a_escalation_and_advisor_fallback_explicit() {
         || bad="$bad AI_SETUP_LANES.md:driver-swap"
     grep -q 'spawn a Fable subagent' "$REPO_ROOT/AI_SETUP_LANES.md" \
         || bad="$bad AI_SETUP_LANES.md:advisor-fallback"
-    grep -q 'takes over as driver' "$REPO_ROOT/README.md" \
-        || bad="$bad README.md:driver-swap"
-    grep -q 'spawn a Fable subagent' "$REPO_ROOT/README.md" \
-        || bad="$bad README.md:advisor-fallback"
+    # "Reading Setup A precisely" moved from README to AI_SETUP_LANES.md, so the
+    # two prose assertions are made once, above, against the file that now
+    # carries them. README keeps a POINTER, and the pointer is asserted here so
+    # it cannot rot into a dead reference to prose that lives elsewhere.
+    grep -q 'how to read Setup A precisely' "$REPO_ROOT/README.md" \
+        || bad="$bad README.md:missing-pointer-to-setup-a-detail"
+    grep -q 'AI_SETUP_LANES.md' "$REPO_ROOT/README.md" \
+        || bad="$bad README.md:missing-lanes-link"
     # Negative half (Codex round-1 P1-3): positive assertions alone false-green
     # while the advisor-outage procedure still offers a "no advisor" path. The
     # outage section must route to the subagent fallback, never to skipping.

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1984,7 +1984,14 @@ test_setup_a_escalation_and_advisor_fallback_explicit() {
     ptr_para="$(awk 'BEGIN{RS=""} /how to read Setup A precisely/' "$REPO_ROOT/README.md")"
     if [ -z "$ptr_para" ]; then
         bad="$bad README.md:missing-pointer-to-setup-a-detail"
-    elif ! printf '%s' "$ptr_para" | grep -q '(AI_SETUP_LANES\.md)\|(\./AI_SETUP_LANES\.md)\|AI_SETUP_LANES\.md#'; then
+    # Seat 1 round 2 (2026-08-17): the same-paragraph binding above was still
+    # vacuous, and for the same reason one scope narrower. That paragraph also
+    # carries a SECOND link, to the billing anchor, which satisfied the
+    # `AI_SETUP_LANES.md#` alternative on its own. Stripping the pointer's link
+    # or retargeting it to CHANGELOG.md both stayed green. So the target must
+    # now be the ANCHORLESS file link — the one only the pointer can supply,
+    # since every anchored link in this paragraph carries a `#`.
+    elif ! printf '%s' "$ptr_para" | grep -q '\](AI_SETUP_LANES\.md)\|\](\./AI_SETUP_LANES\.md)'; then
         bad="$bad README.md:setup-a-pointer-carries-no-link-to-AI_SETUP_LANES.md"
     fi
     # Negative half (Codex round-1 P1-3): positive assertions alone false-green

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1980,19 +1980,26 @@ test_setup_a_escalation_and_advisor_fallback_explicit() {
     # entirely, or link to the wrong file, while the guard stayed green.
     # Requiring both facts in the SAME paragraph is what makes the second one
     # say something about the first.
-    local ptr_para
-    ptr_para="$(awk 'BEGIN{RS=""} /how to read Setup A precisely/' "$REPO_ROOT/README.md")"
-    if [ -z "$ptr_para" ]; then
-        bad="$bad README.md:missing-pointer-to-setup-a-detail"
-    # Seat 1 round 2 (2026-08-17): the same-paragraph binding above was still
-    # vacuous, and for the same reason one scope narrower. That paragraph also
-    # carries a SECOND link, to the billing anchor, which satisfied the
-    # `AI_SETUP_LANES.md#` alternative on its own. Stripping the pointer's link
-    # or retargeting it to CHANGELOG.md both stayed green. So the target must
-    # now be the ANCHORLESS file link — the one only the pointer can supply,
-    # since every anchored link in this paragraph carries a `#`.
-    elif ! printf '%s' "$ptr_para" | grep -q '\](AI_SETUP_LANES\.md)\|\](\./AI_SETUP_LANES\.md)'; then
-        bad="$bad README.md:setup-a-pointer-carries-no-link-to-AI_SETUP_LANES.md"
+    # Seat 1 rounds 1-3 (2026-08-17) each killed a narrower version of the
+    # same defect, so the third fix changes the PRINCIPLE instead of the
+    # pattern. Every earlier attempt asserted "a link to AI_SETUP_LANES.md
+    # exists somewhere in a REGION" — first the file, then the paragraph, then
+    # the paragraph restricted to anchorless links. Any region wide enough to
+    # contain the pointer also contains its neighbours, so a sibling link
+    # always satisfied the check on the pointer's behalf.
+    #
+    # A markdown link binds phrase and destination in ONE construct. Checking
+    # the construct makes sibling links irrelevant by construction rather than
+    # by how today's prose happens to be written, which is why the region
+    # extraction is gone rather than tightened. The trailing paren is
+    # deliberately absent: an anchor is allowed, because the guard's job is to
+    # stop a dead reference to a file, not to police which section.
+    if ! grep -q '\[how to read Setup A precisely\](AI_SETUP_LANES\.md' "$REPO_ROOT/README.md"; then
+        if grep -q 'how to read Setup A precisely' "$REPO_ROOT/README.md"; then
+            bad="$bad README.md:setup-a-pointer-is-not-a-link-to-AI_SETUP_LANES.md"
+        else
+            bad="$bad README.md:missing-pointer-to-setup-a-detail"
+        fi
     fi
     # Negative half (Codex round-1 P1-3): positive assertions alone false-green
     # while the advisor-outage procedure still offers a "no advisor" path. The

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1980,27 +1980,20 @@ test_setup_a_escalation_and_advisor_fallback_explicit() {
     # entirely, or link to the wrong file, while the guard stayed green.
     # Requiring both facts in the SAME paragraph is what makes the second one
     # say something about the first.
-    # Seat 1 rounds 1-3 (2026-08-17) each killed a narrower version of the
-    # same defect, so the third fix changes the PRINCIPLE instead of the
-    # pattern. Every earlier attempt asserted "a link to AI_SETUP_LANES.md
-    # exists somewhere in a REGION" — first the file, then the paragraph, then
-    # the paragraph restricted to anchorless links. Any region wide enough to
-    # contain the pointer also contains its neighbours, so a sibling link
-    # always satisfied the check on the pointer's behalf.
+    # The README pointer guard that lived here is DELETED, routed to #672
+    # under the #530 rule: a guard whose review cost exceeds what it guards
+    # goes to a follow-up rather than getting patched again. Four consecutive
+    # P1 rounds on one sentence. Rounds 1-3 were one defect at narrowing scope
+    # — assert a link exists in a REGION, which any sibling link satisfies on
+    # the pointer's behalf. Round 4 changed the principle to check the
+    # CONSTRUCT, closed that class, and opened a new one: the match ended
+    # before the file boundary, so AI_SETUP_LANES.md.bak passed 137/0.
     #
-    # A markdown link binds phrase and destination in ONE construct. Checking
-    # the construct makes sibling links irrelevant by construction rather than
-    # by how today's prose happens to be written, which is why the region
-    # extraction is gone rather than tightened. The trailing paren is
-    # deliberately absent: an anchor is allowed, because the guard's job is to
-    # stop a dead reference to a file, not to police which section.
-    if ! grep -q '\[how to read Setup A precisely\](AI_SETUP_LANES\.md' "$REPO_ROOT/README.md"; then
-        if grep -q 'how to read Setup A precisely' "$REPO_ROOT/README.md"; then
-            bad="$bad README.md:setup-a-pointer-is-not-a-link-to-AI_SETUP_LANES.md"
-        else
-            bad="$bad README.md:missing-pointer-to-setup-a-detail"
-        fi
-    fi
+    # The replacement is generic, not bespoke — assert every relative link
+    # target in shipped markdown resolves to a file that exists. That is what
+    # four rounds of one-sentence regex were reaching for. Deleted whole:
+    # a surviving half re-seeds the region concept.
+
     # Negative half (Codex round-1 P1-3): positive assertions alone false-green
     # while the advisor-outage procedure still offers a "no advisor" path. The
     # outage section must route to the subagent fallback, never to skipping.

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1973,10 +1973,20 @@ test_setup_a_escalation_and_advisor_fallback_explicit() {
     # two prose assertions are made once, above, against the file that now
     # carries them. README keeps a POINTER, and the pointer is asserted here so
     # it cannot rot into a dead reference to prose that lives elsewhere.
-    grep -q 'how to read Setup A precisely' "$REPO_ROOT/README.md" \
-        || bad="$bad README.md:missing-pointer-to-setup-a-detail"
-    grep -q 'AI_SETUP_LANES.md' "$REPO_ROOT/README.md" \
-        || bad="$bad README.md:missing-lanes-link"
+    # The two checks must be BOUND TO EACH OTHER, not merely both true. Seat 1
+    # (2026-08-17) showed the earlier pair was satisfiable by accident: a bare
+    # `grep AI_SETUP_LANES.md README.md` is already true because of an
+    # unrelated link elsewhere in the file, so the pointer could lose its link
+    # entirely, or link to the wrong file, while the guard stayed green.
+    # Requiring both facts in the SAME paragraph is what makes the second one
+    # say something about the first.
+    local ptr_para
+    ptr_para="$(awk 'BEGIN{RS=""} /how to read Setup A precisely/' "$REPO_ROOT/README.md")"
+    if [ -z "$ptr_para" ]; then
+        bad="$bad README.md:missing-pointer-to-setup-a-detail"
+    elif ! printf '%s' "$ptr_para" | grep -q '(AI_SETUP_LANES\.md)\|(\./AI_SETUP_LANES\.md)\|AI_SETUP_LANES\.md#'; then
+        bad="$bad README.md:setup-a-pointer-carries-no-link-to-AI_SETUP_LANES.md"
+    fi
     # Negative half (Codex round-1 P1-3): positive assertions alone false-green
     # while the advisor-outage procedure still offers a "no advisor" path. The
     # outage section must route to the subagent fallback, never to skipping.


### PR DESCRIPTION
## The problem

`README.md`'s "Choosing Your Model" was **1360 words**, and its largest block argued the case for Opus 4.6 over 4.8 — a debate settled two defaults ago, drawn from third-party field reports, about a configuration **no cycle of this harness has ever run on**. A reader had to get through all of it to find out which model to use.

The dishonesty was one of **proportion, not of fact**. Nothing in that section was false. But the space it took implied a body of evidence behind those lanes that does not exist.

## What changed

The section is now **471 words**: the default, an explicit statement of what has actually been exercised, the switch commands, the lane table, and a pointer. The new honesty note says it plainly:

> **What has actually been exercised on this harness:** Setup A only — Opus 5 driving, Fable 5 advising, GPT-5.6 Sol gating. [...] The other lanes and the `claude-opus-4-6` / `claude-opus-4-8` pins are supported and reachable, but **no one has run a cycle of this harness on them.** [...] Treat their entries below as configuration that should work, not as measured results.

The 4.6/4.8 research, the per-model effort wall, and "Reading Setup A precisely" **move** to `AI_SETUP_LANES.md` under "Model Selection — The Evidence". **Nothing is deleted and no recommendation changes.**

## The guards followed the content

Four guards in `test-doc-consistency.sh` pinned that content to `README.md`, two of them by line number. They are **repointed, not relaxed** — every claim is still asserted, against the file that now carries it. The position pins became content matches, which is what #659 asked for: they had already been re-anchored once and broke again on this move.

Each rewritten guard was **verified by mutation**, not by reading:

| Mutation | Result |
|---|---|
| reintroduce GPT-5.5 into README | CAUGHT |
| rewrite the historical Vending-Bench citation to 5.6 | CAUGHT |
| delete the Sonnet 5 `medium` effort default | CAUGHT |
| remove README's pointer to the Setup A detail | CAUGHT |

## Verification

`test-doc-consistency` 137/0, `test-docs-usability` 29/0, `test-cowork-drift` 30/0, `test-workflow-triggers` 169/0.

## Merge status

Needs its own dual clearance — `README.md` ships (npm includes it automatically). Seat 1 is unavailable until the Codex usage limit resets on **Aug 19 21:00**.
