### PR TITLE
fix(merge-gate): pin the repository the gate talks to

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -136,7 +136,7 @@ verify_cross_model_clearance() {
     fi
     local comments records who conf sha author reviewers="" count=0
     CLEARED_BY=""
-    if ! comments=$(gh api --paginate "repos/:owner/:repo/issues/$PR_NUM/comments" 2>&1); then
+    if ! comments=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness --paginate "repos/:owner/:repo/issues/$PR_NUM/comments" 2>&1); then
         echo "FAILED CLOSED: could not fetch PR comments for #$PR_NUM: $comments" >&2
         return 1
     fi
@@ -454,7 +454,7 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if ! PR_JSON=$(gh pr view "$PR_NUM" --json headRefOid,number,state,baseRefName 2>&1); then
+if ! PR_JSON=$(gh pr view -R github.com/BaseInfinity/claude-sdlc-harness "$PR_NUM" --json headRefOid,number,state,baseRefName 2>&1); then
     echo "FAILED CLOSED: could not fetch PR #$PR_NUM (gh error): $PR_JSON" >&2
     exit 1
 fi
@@ -492,7 +492,7 @@ fi
 # `baseRefOid` is therefore deliberately NOT in the `pr view --json` list above:
 # a trap field left parsed is a regression waiting to be reintroduced. The ref
 # endpoint below is the branch tip itself.
-if ! BASE_REF_JSON=$(gh api "repos/{owner}/{repo}/git/ref/heads/$BASE_BRANCH" 2>&1); then
+if ! BASE_REF_JSON=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness "repos/{owner}/{repo}/git/ref/heads/$BASE_BRANCH" 2>&1); then
     echo "FAILED CLOSED: could not read the current tip of $BASE_BRANCH (gh error): $BASE_REF_JSON" >&2
     exit 1
 fi
@@ -514,14 +514,14 @@ fi
     # invalid `gh pr diff -- <path>` call (gh pr diff has no per-path
     # filter flag; that call errors with stderr suppressed, so the check
     # silently no-opped — Codex round-1 finding). ---
-    if ! PR_FILES=$(gh api --paginate "repos/:owner/:repo/pulls/$PR_NUM/files" 2>&1); then
+    if ! PR_FILES=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness --paginate "repos/:owner/:repo/pulls/$PR_NUM/files" 2>&1); then
         echo "FAILED CLOSED: could not fetch file statuses for PR #$PR_NUM: $PR_FILES" >&2
         exit 1
     fi
 
     # --- Denylist / release-policy-adjacency check (checked first so the
     # self-referential case fails loud and immediately) ---
-    if ! DIFF_FILES=$(gh pr diff "$PR_NUM" --name-only 2>&1); then
+    if ! DIFF_FILES=$(gh pr diff -R github.com/BaseInfinity/claude-sdlc-harness "$PR_NUM" --name-only 2>&1); then
         echo "FAILED CLOSED: could not fetch diff for PR #$PR_NUM: $DIFF_FILES" >&2
         exit 1
     fi
@@ -554,7 +554,7 @@ fi
     # Codex round-3: `|| echo ""` turned an API/CLI failure into "skip the
     # check" — precisely the condition that must fail closed. A HARD file past
     # the files-API ceiling was invisible whenever this second query failed.
-    if ! CHANGED_COUNT=$(gh pr view "$PR_NUM" --json changedFiles --jq '.changedFiles' 2>/dev/null); then
+    if ! CHANGED_COUNT=$(gh pr view -R github.com/BaseInfinity/claude-sdlc-harness "$PR_NUM" --json changedFiles --jq '.changedFiles' 2>/dev/null); then
         echo "FAILED CLOSED: could not read changedFiles for PR #$PR_NUM — cannot prove the classified path set is complete." >&2
         exit 1
     fi
@@ -694,7 +694,7 @@ fi
     # validate" meant "every run on page one" and a red duplicate on page two was
     # invisible (Codex round 1). Same defect the files endpoint already carries a
     # comment about.
-    if ! CHECK_RUNS=$(gh api --paginate "repos/:owner/:repo/commits/$HEAD_SHA/check-runs" 2>&1); then
+    if ! CHECK_RUNS=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness --paginate "repos/:owner/:repo/commits/$HEAD_SHA/check-runs" 2>&1); then
         echo "FAILED CLOSED: could not fetch check-runs for $HEAD_SHA: $CHECK_RUNS" >&2
         exit 1
     fi
@@ -1218,7 +1218,7 @@ if [ -n "$USER_APPROVED_REASON" ]; then
         "$USER_APPROVED_REASON" \
         "$(printf '%s\n' "$WAIVED_PATHS" | sed '/^$/d' | sed 's/^/- `/; s/$/`/')" \
         "$HEAD_SHA")
-    if ! gh pr comment "$PR_NUM" --body "$OVERRIDE_BODY" >/dev/null 2>&1; then
+    if ! gh pr comment -R github.com/BaseInfinity/claude-sdlc-harness "$PR_NUM" --body "$OVERRIDE_BODY" >/dev/null 2>&1; then
         echo "BLOCKED: could not post the override record to PR #$PR_NUM. Refusing to merge — an unrecorded override is precisely what --user-approved exists to prevent." >&2
         exit 1
     fi
@@ -1237,7 +1237,7 @@ if [ -n "$DUAL_PATHS" ]; then
         "$CLEARED_BY" \
         "$HEAD_SHA" \
         "$(printf '%s' "$DUAL_PATHS" | sed '/^$/d' | sed 's/^/- `/; s/$/`/')")
-    if ! gh pr comment "$PR_NUM" --body "$DUAL_BODY" >/dev/null 2>&1; then
+    if ! gh pr comment -R github.com/BaseInfinity/claude-sdlc-harness "$PR_NUM" --body "$DUAL_BODY" >/dev/null 2>&1; then
         echo "BLOCKED: could not post the dual-certification record to PR #$PR_NUM. Refusing to merge — a merge-evidence path cleared without a durable record is the exact gap #511 exists to close." >&2
         exit 1
     fi
@@ -1247,7 +1247,7 @@ fi
 # --- Execute: always squash, no passthrough flags, atomically bound to the
 # checked SHA. Only the PR number is accepted as input, closing the
 # flag-smuggling surface entirely. ---
-MERGE_OUTPUT=$(gh pr merge "$PR_NUM" --squash --match-head-commit "$HEAD_SHA" 2>&1)
+MERGE_OUTPUT=$(gh pr merge -R github.com/BaseInfinity/claude-sdlc-harness "$PR_NUM" --squash --match-head-commit "$HEAD_SHA" 2>&1)
 MERGE_EXIT=$?
 if [ "$MERGE_EXIT" -ne 0 ]; then
     echo "FAILED: gh pr merge did not succeed (possibly a race — head moved after checks passed): $MERGE_OUTPUT" >&2

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -57,7 +57,13 @@ set -u
 # not a gate.
 #
 # These exports override whatever the caller set, so every gh invocation in
-# this file resolves here — including any added later, in whatever form.
+# this file ISSUES ITS REQUEST here — including any added later, in whatever
+# form. Read that precisely: it is the INITIAL request URL that is pinned.
+# `--paginate` follows the absolute URL the server returns in its Link header
+# and uses it directly, so a server that returned a cross-host Link would send
+# the follow-up request there regardless of GH_HOST or --hostname. Round 3's
+# review found the earlier wording here claimed every request stays pinned,
+# which is more than is true.
 # Two rounds of review were spent instead trying to PROVE that property by
 # scanning this file's text for per-call flags, and the scanner was wrong both
 # times, the second time in a way the first fix created. Holding the property
@@ -73,9 +79,11 @@ set -u
 # refactor that removes the other.
 #
 # NOT CLOSED BY THIS, and it is the other half of the same round-3 finding:
-# GIT_DIR/GIT_WORK_TREE still redirect this script's own `git` calls. That is
-# a separate channel from gh's, and it is tracked separately — do not read
-# these two lines as closing it.
+# GIT_DIR still redirects this script's own `git` calls — optionally paired
+# with GIT_WORK_TREE, though GIT_WORK_TREE ALONE does not, since it leaves
+# this repository's own .git and its origin/main resolution intact. That is a
+# separate channel from gh's, tracked in #681 — do not read these two lines as
+# closing it.
 export GH_HOST=github.com
 export GH_REPO=BaseInfinity/claude-sdlc-harness
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -47,7 +47,7 @@
 
 set -u
 
-# --- THE REPOSITORY AND HOST THIS GATE ACTS ON ARE PINNED HERE, ONCE ---
+# --- THE REPOSITORY AND HOST THIS GATE ACTS ON ARE PINNED HERE ---
 #
 # #607 round 3: repository selection in this script was AMBIENT. gh honours
 # GH_REPO and GH_HOST, git honours GIT_DIR and GIT_WORK_TREE, and `cd` binds
@@ -56,34 +56,44 @@ set -u
 # an unrelated repository. A gate that can be aimed at another repository is
 # not a gate.
 #
-# These exports override whatever the caller set, so every gh invocation in
-# this file ISSUES ITS REQUEST here — including any added later, in whatever
-# form. Read that precisely: it is the INITIAL request URL that is pinned.
-# `--paginate` follows the absolute URL the server returns in its Link header
-# and uses it directly, so a server that returned a cross-host Link would send
-# the follow-up request there regardless of GH_HOST or --hostname. Round 3's
-# review found the earlier wording here claimed every request stays pinned,
-# which is more than is true.
-# Two rounds of review were spent instead trying to PROVE that property by
-# scanning this file's text for per-call flags, and the scanner was wrong both
-# times, the second time in a way the first fix created. Holding the property
-# by construction is what ended that.
+# These exports override whatever the CALLER set. Verified by execution
+# against real gh 2.92.0 and real github.com: with GH_HOST=example.invalid,
+# GH_REPO=example.invalid/evil/wrong and GIT_DIR=/tmp/nope.git in the parent
+# environment, requests still reached Host: api.github.com and this
+# repository, including from a call carrying no per-call flags at all.
 #
-# BOTH LINES ARE LOAD-BEARING. GH_REPO takes a HOST/OWNER/REPO form, so it
-# looks like it pins the host as well. It does not: with GH_REPO set correctly
-# and a hostile GH_HOST, the request went to `Host: example.invalid` on the
-# `/api/v3/` enterprise path. GH_HOST wins, and it must be pinned separately.
+# WHAT THAT DOES AND DOES NOT ESTABLISH — this comment claimed more than was
+# true for two rounds, so it is now written narrowly on purpose:
 #
-# The per-call `-R` and `--hostname github.com` flags below are kept as well.
-# They are redundant with these exports on purpose: each layer survives a
-# refactor that removes the other.
+#   * It pins calls that do not override it. It is NOT a guarantee about
+#     "every present and future invocation". An inline `GH_REPO=x gh …`, a
+#     per-call `-R` or `--hostname`, or a literal owner/repo in an API path
+#     all take precedence over these lines. Each of those was demonstrated.
+#   * It pins the INITIAL request URL. `--paginate` follows the absolute URL
+#     a server returns in its Link header and uses it directly, so a server
+#     returning a cross-host Link would send the follow-up request there
+#     regardless of GH_HOST or --hostname.
+#   * BOTH LINES ARE LOAD-BEARING. GH_REPO takes a HOST/OWNER/REPO form and
+#     looks like it pins the host too. It does not: with GH_REPO set correctly
+#     and a hostile GH_HOST, the request went to Host: example.invalid on the
+#     /api/v3/ enterprise path. GH_HOST wins and must be pinned separately.
 #
-# NOT CLOSED BY THIS, and it is the other half of the same round-3 finding:
-# GIT_DIR still redirects this script's own `git` calls — optionally paired
-# with GIT_WORK_TREE, though GIT_WORK_TREE ALONE does not, since it leaves
-# this repository's own .git and its origin/main resolution intact. That is a
-# separate channel from gh's, tracked in #681 — do not read these two lines as
-# closing it.
+# The per-call `-R` and `--hostname github.com` flags below are kept as a
+# second layer. NOT VERIFIED, and previously asserted here as though it were:
+# that either layer independently survives deletion of the other at all ten
+# call sites. Only the merge call has its exact argv asserted by the suite,
+# and the exports were only ever observed as environment values. Treat the two
+# layers as belt and braces, not as two independently proven guarantees.
+#
+# NOT CLOSED BY THIS: GIT_DIR still redirects this script's own `git` calls —
+# optionally paired with GIT_WORK_TREE, though GIT_WORK_TREE ALONE does not,
+# since it leaves this repository's .git and its origin/main resolution
+# intact. Those calls are load-bearing for the self-integrity byte-match and
+# for clearance tree binding. Separate channel from gh's, tracked in #681.
+#
+# There is no test in this repo that proves the pin holds for a call added
+# later. Four were written and all four were deleted for reporting a property
+# they did not check — see the long note in tests/test-merge-gate.sh.
 export GH_HOST=github.com
 export GH_REPO=BaseInfinity/claude-sdlc-harness
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -47,6 +47,39 @@
 
 set -u
 
+# --- THE REPOSITORY AND HOST THIS GATE ACTS ON ARE PINNED HERE, ONCE ---
+#
+# #607 round 3: repository selection in this script was AMBIENT. gh honours
+# GH_REPO and GH_HOST, git honours GIT_DIR and GIT_WORK_TREE, and `cd` binds
+# neither. The reviewer demonstrated it by running it — with GIT_DIR pointed
+# elsewhere, every check below reported success while the requests resolved to
+# an unrelated repository. A gate that can be aimed at another repository is
+# not a gate.
+#
+# These exports override whatever the caller set, so every gh invocation in
+# this file resolves here — including any added later, in whatever form.
+# Two rounds of review were spent instead trying to PROVE that property by
+# scanning this file's text for per-call flags, and the scanner was wrong both
+# times, the second time in a way the first fix created. Holding the property
+# by construction is what ended that.
+#
+# BOTH LINES ARE LOAD-BEARING. GH_REPO takes a HOST/OWNER/REPO form, so it
+# looks like it pins the host as well. It does not: with GH_REPO set correctly
+# and a hostile GH_HOST, the request went to `Host: example.invalid` on the
+# `/api/v3/` enterprise path. GH_HOST wins, and it must be pinned separately.
+#
+# The per-call `-R` and `--hostname github.com` flags below are kept as well.
+# They are redundant with these exports on purpose: each layer survives a
+# refactor that removes the other.
+#
+# NOT CLOSED BY THIS, and it is the other half of the same round-3 finding:
+# GIT_DIR/GIT_WORK_TREE still redirect this script's own `git` calls. That is
+# a separate channel from gh's, and it is tracked separately — do not read
+# these two lines as closing it.
+export GH_HOST=github.com
+export GH_REPO=BaseInfinity/claude-sdlc-harness
+
+
 # --- Two tiers (ROADMAP #479). Codex xhigh (96%) and Fable xhigh (85%),
 # consulted independently and blind to each other, both recommended this split.
 #

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -136,7 +136,7 @@ verify_cross_model_clearance() {
     fi
     local comments records who conf sha author reviewers="" count=0
     CLEARED_BY=""
-    if ! comments=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness --paginate "repos/:owner/:repo/issues/$PR_NUM/comments" 2>&1); then
+    if ! comments=$(gh api --hostname github.com --paginate "repos/BaseInfinity/claude-sdlc-harness/issues/$PR_NUM/comments" 2>&1); then
         echo "FAILED CLOSED: could not fetch PR comments for #$PR_NUM: $comments" >&2
         return 1
     fi
@@ -492,7 +492,7 @@ fi
 # `baseRefOid` is therefore deliberately NOT in the `pr view --json` list above:
 # a trap field left parsed is a regression waiting to be reintroduced. The ref
 # endpoint below is the branch tip itself.
-if ! BASE_REF_JSON=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness "repos/{owner}/{repo}/git/ref/heads/$BASE_BRANCH" 2>&1); then
+if ! BASE_REF_JSON=$(gh api --hostname github.com "repos/BaseInfinity/claude-sdlc-harness/git/ref/heads/$BASE_BRANCH" 2>&1); then
     echo "FAILED CLOSED: could not read the current tip of $BASE_BRANCH (gh error): $BASE_REF_JSON" >&2
     exit 1
 fi
@@ -514,7 +514,7 @@ fi
     # invalid `gh pr diff -- <path>` call (gh pr diff has no per-path
     # filter flag; that call errors with stderr suppressed, so the check
     # silently no-opped — Codex round-1 finding). ---
-    if ! PR_FILES=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness --paginate "repos/:owner/:repo/pulls/$PR_NUM/files" 2>&1); then
+    if ! PR_FILES=$(gh api --hostname github.com --paginate "repos/BaseInfinity/claude-sdlc-harness/pulls/$PR_NUM/files" 2>&1); then
         echo "FAILED CLOSED: could not fetch file statuses for PR #$PR_NUM: $PR_FILES" >&2
         exit 1
     fi
@@ -694,7 +694,7 @@ fi
     # validate" meant "every run on page one" and a red duplicate on page two was
     # invisible (Codex round 1). Same defect the files endpoint already carries a
     # comment about.
-    if ! CHECK_RUNS=$(gh api -R github.com/BaseInfinity/claude-sdlc-harness --paginate "repos/:owner/:repo/commits/$HEAD_SHA/check-runs" 2>&1); then
+    if ! CHECK_RUNS=$(gh api --hostname github.com --paginate "repos/BaseInfinity/claude-sdlc-harness/commits/$HEAD_SHA/check-runs" 2>&1); then
         echo "FAILED CLOSED: could not fetch check-runs for $HEAD_SHA: $CHECK_RUNS" >&2
         exit 1
     fi

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -381,6 +381,15 @@ CONFIG="$(dirname "$0")/../.gh-stub-config"
 # shellcheck disable=SC1090
 [ -f "$CONFIG" ] && source "$CONFIG"
 
+# Record the pin environment THIS invocation actually saw, before doing
+# anything else. Round 3's review ruled the source-level pin guards
+# WRONG_SHAPE; this log is what replaces them, because it observes the
+# runtime property the exports claim rather than the text that sets them.
+# `-` stands in for unset so an absent variable is distinguishable from an
+# empty one.
+printf '%s\n' "GH_PIN_ENV: host=${GH_HOST:--} repo=${GH_REPO:--} argv=$*" \
+    >> "$(dirname "$0")/../.gh-pin-env"
+
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
     # The wrapper now asks for changedFiles separately to prove the classified
     # path set is complete; answer with the fixture's real count.
@@ -2179,38 +2188,19 @@ test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
 # lines, a banned set of placeholder tokens, and a required literal path. Each
 # errs toward false-FAIL — a stray `:owner` in a trailing comment trips row 2,
 # which is a loud nuisance rather than a silent pass.
-GATE_REPO_PATH='repos/BaseInfinity/claude-sdlc-harness/'
-
-# Row 1: the gate exports both pins, before it uses gh.
-#
-# Raw grep on the file, deliberately. Anything cleverer is the mistake rounds
-# 1 and 2 already made twice.
-test_gate_exports_both_pins_before_using_gh() {
-    local host_line repo_line first_gh
-    host_line=$(grep -n '^export GH_HOST=github\.com$' "$WRAPPER" | head -1 | cut -d: -f1)
-    repo_line=$(grep -n '^export GH_REPO=BaseInfinity/claude-sdlc-harness$' "$WRAPPER" | head -1 | cut -d: -f1)
-    first_gh=$(grep -nE '(^|[^[:alnum:]_./-])gh[[:space:]]' "$WRAPPER" \
-        | grep -vE '^[0-9]+:[[:space:]]*#' | head -1 | cut -d: -f1)
-    if [ -z "$host_line" ]; then
-        fail "the gate does not export GH_HOST=github.com — the host is ambient and GH_HOST beats GH_REPO's host prefix"
-    elif [ -z "$repo_line" ]; then
-        fail "the gate does not export GH_REPO=BaseInfinity/claude-sdlc-harness — the repository is ambient"
-    elif [ -z "$first_gh" ]; then
-        fail "no gh invocation found in the gate at all — this row's premise is broken, not satisfied"
-    elif [ "$host_line" -lt "$first_gh" ] && [ "$repo_line" -lt "$first_gh" ]; then
-        pass "the gate exports GH_HOST and GH_REPO before its first gh invocation"
-    else
-        fail "the gate's pin exports (GH_HOST line $host_line, GH_REPO line $repo_line) do not both precede its first gh use (line $first_gh)"
-    fi
-}
-
-# Row 2: no ambient owner/repo placeholder token survives anywhere.
+# Row 1: no ambient owner/repo placeholder token survives anywhere.
 #
 # `:owner`, `:repo`, `{owner}` and `{repo}` are resolved by gh from the current
-# directory or GH_REPO. Round 2's review found the previous version enumerated
+# directory or GH_REPO. Round 2's review found an earlier version enumerated
 # only the two matched PAIRS, so the mixed form `repos/{owner}/:repo` was
 # invisible — and gh resolves that form perfectly well, verified by running it.
 # Banning the TOKENS rather than the pairs is what removes the combinatorics.
+#
+# THIS IS THE ONE SOURCE-LEVEL ROW THAT SURVIVED ROUND 3, and the reason it did
+# is the reason the others did not: it errs toward false-FAIL. A stray `:repo`
+# in a trailing comment fails this row loudly. That is a nuisance. Every row
+# deleted below erred the other way, and a guard that errs toward false-PASS is
+# not a guard, it is a report that nothing was examined.
 test_no_ambient_repo_placeholder_in_the_gate() {
     local placeholders
     placeholders=$(grep -nE ':owner|:repo|\{owner\}|\{repo\}' "$WRAPPER" \
@@ -2222,27 +2212,73 @@ test_no_ambient_repo_placeholder_in_the_gate() {
     fi
 }
 
-# Row 3: every API path names THIS repository literally.
+# Row 2: BEHAVIOURAL. Every gh invocation the gate actually makes sees the pin.
 #
-# The exports do not close this one. A literal path beats the environment, so
-# a call written against another literal repository would be pinned — at the
-# wrong target. Round 2's review found the previous version defined a constant
-# for this and then never used it.
-test_every_api_path_names_this_repository() {
-    local wrong
-    wrong=$(grep -n 'repos/' "$WRAPPER" \
-        | grep -vE '^[0-9]+:[[:space:]]*#' \
-        | grep -v "$GATE_REPO_PATH" || true)
-    if [ -z "$wrong" ]; then
-        pass "every API path in the gate names this repository literally"
+# ---------------------------------------------------------------------------
+# THREE SOURCE-LEVEL GUARDS WERE WRITTEN FOR THIS PROPERTY AND ALL THREE WERE
+# WRONG. Round 3's review ruled the genre WRONG_SHAPE at confidence 99.
+#
+#   Round 1 grepped for three fixed call prefixes and took the substring `-R `
+#   anywhere on the line as proof of a pin. A trailing comment satisfied it.
+#
+#   Round 2 blanked quoted strings and comments first, then checked whatever
+#   `gh` survived. It ERASED real calls: `X="$(gh pr list)"` disappears with
+#   the quotes around it, and the count row added to catch that cannot, since
+#   an erased addition leaves the count unchanged.
+#
+#   Round 3 checked that the exports appear before the first gh use, and that
+#   every `repos/` line names this repository. Both still passed on inputs
+#   that break the property: a later `unset GH_REPO`, a per-command
+#   `GH_REPO=evil gh …` override, a path-qualified `/usr/bin/gh`, and a wrong
+#   literal target whose line happens to also mention the right one.
+#
+# Each rewrite reproduced the previous one's failure mode in new clothes,
+# because the thing being checked — "what repository will this call reach" —
+# is a RUNTIME property, and shell source text does not determine it. So this
+# row stops reading the file and runs the gate instead.
+#
+# The stub records `GH_HOST` and `GH_REPO` as each invocation actually saw
+# them. The fixture is then run with a HOSTILE environment exported around the
+# wrapper, which is the condition the exports exist for. Every recorded
+# invocation must have seen the pinned values, or the property is broken —
+# however the source happens to be written.
+#
+# This catches what the source-level rows could not: an export deleted, an
+# export unset later in the file, and a per-command override on a single call.
+#
+# STATED LIMIT, and it is shared with every other row in this suite: the stub
+# is reached through PATH, so an invocation written as `/usr/bin/gh` bypasses
+# it and this row cannot see that call at all. Nothing in this file can. It is
+# a limit of stub-based testing, not of this row's design.
+test_every_gh_invocation_sees_the_pin_at_runtime() {
+    local tmpdir out exit_code seen bad
+    tmpdir=$(setup_wrapper_fixture)
+    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
+    echo "content" > "$tmpdir/.reviews/some-review.md"
+    rm -f "$tmpdir/.gh-pin-env"
+
+    # The hostile environment is the whole point of the row. If the gate's own
+    # exports are missing or overridden, these are the values gh would see.
+    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" \
+        GH_HOST=example.invalid \
+        GH_REPO=example.invalid/evil/wrong \
+        "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
+
+    seen=$(cat "$tmpdir/.gh-pin-env" 2>/dev/null || true)
+    bad=$(printf '%s\n' "$seen" | grep -v 'host=github\.com repo=BaseInfinity/claude-sdlc-harness ' || true)
+    rm -rf "$tmpdir"
+
+    if [ -z "$seen" ]; then
+        fail "no gh invocation was recorded at all — this row proved nothing (wrapper exit=$exit_code)"
+    elif [ -n "$bad" ]; then
+        fail "gh invocation(s) ran without the pin despite the gate's exports: $(echo "$bad" | tr '\n' ' ' | cut -c1-300)"
     else
-        fail "API path(s) not naming this repository: $(echo "$wrong" | tr '\n' ' ' | cut -c1-300)"
+        pass "every gh invocation the gate makes sees the pinned host and repository, even under a hostile environment"
     fi
 }
 
-test_gate_exports_both_pins_before_using_gh
 test_no_ambient_repo_placeholder_in_the_gate
-test_every_api_path_names_this_repository
+test_every_gh_invocation_sees_the_pin_at_runtime
 test_wrapper_blocks_unreadable_base_object
 test_wrapper_blocks_clearance_without_trees
 test_wrapper_blocks_empty_review_artifact

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -2024,10 +2024,14 @@ test_wrapper_merges_when_all_conditions_met() {
     echo "content" > "$tmpdir/.reviews/some-review.md"
     out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
     rm -rf "$tmpdir"
-    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED: pr merge 123 --squash --match-head-commit $fixture_sha"; then
-        pass "wrapper merges with the exact expected command when all conditions are met"
+    # The -R pin is asserted, not tolerated (#607). Repository selection was
+    # ambient: with GIT_DIR redirected, the merge targeted another repository
+    # while every check reported success against the wrong target. An unpinned
+    # merge call must fail this row rather than pass it.
+    if [ "$exit_code" -eq 0 ] && echo "$out" | grep -q "GH_MERGE_INVOKED: pr merge -R github.com/BaseInfinity/claude-sdlc-harness 123 --squash --match-head-commit $fixture_sha"; then
+        pass "wrapper merges with the exact expected command, repository pinned, when all conditions are met"
     else
-        fail "wrapper should invoke 'gh pr merge 123 --squash --match-head-commit <fixture sha>', got exit=$exit_code out=$out"
+        fail "wrapper should invoke 'gh pr merge -R <this repo> 123 --squash --match-head-commit <fixture sha>', got exit=$exit_code out=$out"
     fi
 }
 
@@ -2120,6 +2124,32 @@ test_wrapper_blocks_stale_clearance
 test_wrapper_blocks_wrong_candidate_tree
 test_wrapper_blocks_moved_base
 test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
+
+# Test: every gh invocation in the gate pins the repository.
+#
+# #607 round 3. Repository selection was AMBIENT: gh honours GH_REPO/GH_HOST
+# and git honours GIT_DIR/GIT_WORK_TREE, and `cd` binds neither. The reviewer
+# demonstrated it by running it — with GIT_DIR pointed elsewhere, every check
+# reported success while the request resolved to an unrelated repository.
+#
+# Source-level rather than behavioural because the defect is a MISSING call
+# site: a behavioural test can only cover the calls someone remembered to
+# write a fixture for, and the next unpinned call added to this file is
+# exactly the one no fixture exists for.
+test_every_gh_call_in_the_gate_is_pinned() {
+    local unpinned
+    unpinned=$(grep -n '\$(gh \|! gh \|^MERGE_OUTPUT=\$(gh ' "$WRAPPER" \
+        | grep -v '^[0-9]*:\s*#' \
+        | grep -v -- '-R ' || true)
+    if [ -z "$unpinned" ]; then
+        pass "every gh invocation in the gate pins the repository"
+    else
+        fail "unpinned gh call(s) in the gate: $(echo "$unpinned" | tr '\n' ' ' | cut -c1-200)"
+    fi
+}
+
+
+test_every_gh_call_in_the_gate_is_pinned
 test_wrapper_blocks_unreadable_base_object
 test_wrapper_blocks_clearance_without_trees
 test_wrapper_blocks_empty_review_artifact

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -2125,179 +2125,124 @@ test_wrapper_blocks_wrong_candidate_tree
 test_wrapper_blocks_moved_base
 test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
 
-# Test: every gh invocation in the gate pins BOTH the repository and the host.
+# ---------------------------------------------------------------------------
+# THE GATE'S REPOSITORY AND HOST ARE PINNED BY CONSTRUCTION, AND THESE ROWS
+# CHECK THAT — THEY DO NOT PARSE SHELL.
 #
 # #607 round 3. Repository selection was AMBIENT: gh honours GH_REPO/GH_HOST
 # and git honours GIT_DIR/GIT_WORK_TREE, and `cd` binds neither. The reviewer
 # demonstrated it by running it — with GIT_DIR pointed elsewhere, every check
 # reported success while the request resolved to an unrelated repository.
 #
-# Source-level rather than behavioural because the defect is a MISSING call
-# site: a behavioural test can only cover the calls someone remembered to
-# write a fixture for, and the next unpinned call added to this file is
-# exactly the one no fixture exists for.
+# TWO ROUNDS OF REVIEW WERE SPENT ON THE WRONG SHAPE OF GUARD, and the second
+# round's defect was created by the first round's fix. That is worth recording
+# because it is the same signature that got #607's wrapper ruled WRONG_SHAPE.
 #
-# ---------------------------------------------------------------------------
-# THE TWO SUBCOMMAND FAMILIES PIN DIFFERENTLY, AND THE FIRST VERSION OF THIS
-# CHECK DID NOT KNOW THAT.
+#   Round 1 guarded by grepping for three fixed call prefixes and treating the
+#   substring `-R ` anywhere on the line as proof of a pin. It passed an
+#   unpinned call whose only `-R` sat in a trailing comment, and it could not
+#   see pipeline, backtick, direct or wrapped invocations at all.
 #
-# `gh pr` accepts `-R [HOST/]OWNER/REPO`, which pins host and repository
-# together. `gh api` DOES NOT ACCEPT `-R` AT ALL — gh 2.92.0 exits 1 with
-# "unknown shorthand flag: 'R'". Round 1 of this branch's review found four
-# `gh api` sites carrying `-R`, which would have made the gate abort before
-# reaching a single check. The suite was green over it because the fixture's
-# `gh` stub accepts any argv; the flag was never parsed by real gh.
+#   Round 2 replaced that with a preprocessor: blank single-quoted strings,
+#   then double-quoted strings, then comments, and treat whatever `gh` survived
+#   as a real invocation. Round 2's review falsified it by execution. The line
+#   `X="$(gh pr list --state open)"` — an ordinary form — is erased ENTIRELY,
+#   because the command substitution sits inside the double quotes that get
+#   blanked. The call becomes invisible, and the count row added to catch
+#   exactly that cannot: an erased addition does not change the count.
 #
-# `gh api` is pinned by two things instead, and it needs both:
-#   * a LITERAL owner/repo in the path. `repos/:owner/:repo` and
-#     `repos/{owner}/{repo}` are placeholders gh resolves from the current
-#     directory or GH_REPO — which is the ambient channel being closed.
-#   * `--hostname github.com`. Verified by execution: with a literal path but
-#     GH_HOST=example.invalid, the request went to `Host: example.invalid`.
-#     A literal path alone pins the repository and leaves the HOST ambient.
+# Both failures are the same failure. A text heuristic that errs toward
+# false-PASS is not a guard, it is a report that nothing was examined. So the
+# per-call-site policing is gone, and the property is held by construction
+# instead:
 #
-# ---------------------------------------------------------------------------
-# WHY THIS STRIPS STRINGS AND COMMENTS INSTEAD OF GREPPING FOR CALL PREFIXES.
+#     export GH_HOST=github.com
+#     export GH_REPO=BaseInfinity/claude-sdlc-harness
 #
-# The first version matched three fixed prefixes — `$(gh `, `! gh ` and
-# `^MERGE_OUTPUT=$(gh `. Review enumerated what that misses: direct calls,
-# positive-condition calls, pipelines, backticks, env- and command-wrapped
-# calls, multiline continuations, and alternate whitespace. Every one of those
-# is an ordinary form a future maintainer would write, and each would be added
-# with a green suite.
+# The script's own exports beat the caller's environment, so EVERY gh call —
+# present, future, and in whatever syntactic form a scanner could not parse —
+# resolves to this repository on this host. Verified by execution under a
+# hostile outer environment, real gh 2.92.0, real network: with
+# GH_HOST=example.invalid GH_REPO=example.invalid/evil/wrong GIT_DIR=/tmp/nope.git
+# in the parent, the request still went to `Host: api.github.com` and returned
+# this repository's real ref.
 #
-# Worse, it decided "pinned" by looking for the SUBSTRING `-R ` anywhere on
-# the line, so an unpinned call passed whenever a trailing comment happened to
-# mention `-R`, and a call pinned at the WRONG repository passed unconditioned.
+# BOTH EXPORTS ARE LOAD-BEARING and that is not obvious. GH_REPO accepts a
+# HOST/OWNER/REPO form, so it looks like it should pin the host too. It does
+# not: with GH_REPO set correctly and a hostile GH_HOST, the request went to
+# `Host: example.invalid` on the `/api/v3/` enterprise path. GH_HOST wins.
 #
-# So the file is preprocessed instead: single-quoted strings, double-quoted
-# strings and comments are blanked, and whatever `gh` survives is a real
-# invocation. That is what removes the prose mentions — "could not fetch PR
-# (gh error)", "gh pr merge did not succeed", "posted by the same gh token" —
-# without an allowlist that would have to grow with every new message. The
-# pin is then required ADJACENT to the subcommand rather than anywhere on the
-# line, which is what closes the trailing-comment hole: a comment cannot sit
-# between `gh pr merge` and its own flag.
+# The per-call `-R` and `--hostname` flags stay in place as defense in depth.
+# Each layer covers a refactor that deletes the other.
 #
-# STATED LIMIT: the preprocessor is line-oriented, so a double-quoted string
-# spanning multiple lines leaves an unbalanced quote and the lines after it
-# are stripped on the wrong boundaries. The gate has no such string today and
-# the row below proves the scanner still finds all ten real calls, so a change
-# that introduced one would show up here as a count mismatch, not as silence.
-GATE_PIN='-R github.com/BaseInfinity/claude-sdlc-harness'
+# What remains below checks only things that can be read literally: two export
+# lines, a banned set of placeholder tokens, and a required literal path. Each
+# errs toward false-FAIL — a stray `:owner` in a trailing comment trips row 2,
+# which is a loud nuisance rather than a silent pass.
 GATE_REPO_PATH='repos/BaseInfinity/claude-sdlc-harness/'
 
-# Blank out quoted strings and comments so only real invocations remain.
-gh_invocations_in_the_gate() {
-    sed -e "s/'[^']*'/''/g" -e 's/"[^"]*"/""/g' -e 's/#.*$//' "$WRAPPER" \
-        | grep -nE '(^|[^[:alnum:]_./-])gh[[:space:]]' || true
-}
-
-test_every_gh_call_in_the_gate_is_pinned() {
-    local calls bad="" line
-    calls=$(gh_invocations_in_the_gate)
-    while IFS= read -r line; do
-        [ -n "$line" ] || continue
-        case "$line" in
-            *"gh api"*)
-                # -R is not merely unnecessary here, it is fatal: real gh
-                # exits 1 before performing the request.
-                case "$line" in
-                    *"-R "*) bad="$bad
-gh api cannot take -R: $line" ;;
-                    *"gh api --hostname github.com "*) : ;;
-                    *) bad="$bad
-gh api not host-pinned: $line" ;;
-                esac
-                ;;
-            *"gh "*)
-                case "$line" in
-                    *"$GATE_PIN "*) : ;;
-                    *) bad="$bad
-gh call not repo-pinned: $line" ;;
-                esac
-                ;;
-        esac
-    done <<EOF
-$calls
-EOF
-    if [ -z "$bad" ]; then
-        pass "every gh invocation in the gate pins both the repository and the host"
+# Row 1: the gate exports both pins, before it uses gh.
+#
+# Raw grep on the file, deliberately. Anything cleverer is the mistake rounds
+# 1 and 2 already made twice.
+test_gate_exports_both_pins_before_using_gh() {
+    local host_line repo_line first_gh
+    host_line=$(grep -n '^export GH_HOST=github\.com$' "$WRAPPER" | head -1 | cut -d: -f1)
+    repo_line=$(grep -n '^export GH_REPO=BaseInfinity/claude-sdlc-harness$' "$WRAPPER" | head -1 | cut -d: -f1)
+    first_gh=$(grep -nE '(^|[^[:alnum:]_./-])gh[[:space:]]' "$WRAPPER" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' | head -1 | cut -d: -f1)
+    if [ -z "$host_line" ]; then
+        fail "the gate does not export GH_HOST=github.com — the host is ambient and GH_HOST beats GH_REPO's host prefix"
+    elif [ -z "$repo_line" ]; then
+        fail "the gate does not export GH_REPO=BaseInfinity/claude-sdlc-harness — the repository is ambient"
+    elif [ -z "$first_gh" ]; then
+        fail "no gh invocation found in the gate at all — this row's premise is broken, not satisfied"
+    elif [ "$host_line" -lt "$first_gh" ] && [ "$repo_line" -lt "$first_gh" ]; then
+        pass "the gate exports GH_HOST and GH_REPO before its first gh invocation"
     else
-        fail "unpinned gh call(s) in the gate:$(echo "$bad" | tr '\n' ' ' | cut -c1-300)"
+        fail "the gate's pin exports (GH_HOST line $host_line, GH_REPO line $repo_line) do not both precede its first gh use (line $first_gh)"
     fi
 }
 
-# Test: the pin is adjacent to the subcommand, not merely present on the line.
+# Row 2: no ambient owner/repo placeholder token survives anywhere.
 #
-# Round 1 of review: the old check accepted a line whose only `-R ` was in a
-# trailing comment. Requiring adjacency is what makes that impossible — a
-# comment cannot appear between `gh pr merge` and its own flag.
-test_gh_pin_is_adjacent_to_the_subcommand() {
-    local calls bad="" line
-    calls=$(gh_invocations_in_the_gate)
-    while IFS= read -r line; do
-        [ -n "$line" ] || continue
-        case "$line" in
-            *"gh api"*) continue ;;
-        esac
-        case "$line" in
-            *"gh "*)
-                # gh pr <subcommand> -R <pin>, with nothing in between.
-                if echo "$line" | grep -qE "gh pr [a-z]+ -R github\.com/BaseInfinity/claude-sdlc-harness "; then
-                    :
-                else
-                    bad="$bad
-pin not adjacent to subcommand: $line"
-                fi
-                ;;
-        esac
-    done <<EOF
-$calls
-EOF
-    if [ -z "$bad" ]; then
-        pass "each gh pr pin sits immediately after its subcommand, not elsewhere on the line"
-    else
-        fail "pin not adjacent:$(echo "$bad" | tr '\n' ' ' | cut -c1-300)"
-    fi
-}
-
-# Test: no ambient repository placeholder survives in any gh api path.
-#
-# `:owner/:repo` and `{owner}/{repo}` are resolved by gh from the current
-# directory or GH_REPO. Leaving one in place keeps open the exact channel this
-# branch exists to close, and it cannot be seen by the pin check above because
-# a placeholder path is still a syntactically pinned-looking call.
+# `:owner`, `:repo`, `{owner}` and `{repo}` are resolved by gh from the current
+# directory or GH_REPO. Round 2's review found the previous version enumerated
+# only the two matched PAIRS, so the mixed form `repos/{owner}/:repo` was
+# invisible — and gh resolves that form perfectly well, verified by running it.
+# Banning the TOKENS rather than the pairs is what removes the combinatorics.
 test_no_ambient_repo_placeholder_in_the_gate() {
     local placeholders
-    placeholders=$(grep -nE 'repos/(:owner/:repo|\{owner\}/\{repo\})' "$WRAPPER" || true)
+    placeholders=$(grep -nE ':owner|:repo|\{owner\}|\{repo\}' "$WRAPPER" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' || true)
     if [ -z "$placeholders" ]; then
-        pass "no ambient owner/repo placeholder remains in any gate API path"
+        pass "no ambient owner/repo placeholder token remains anywhere in the gate"
     else
-        fail "ambient placeholder(s) in the gate: $(echo "$placeholders" | tr '\n' ' ' | cut -c1-300)"
+        fail "ambient placeholder token(s) in the gate: $(echo "$placeholders" | tr '\n' ' ' | cut -c1-300)"
     fi
 }
 
-# Test: the scanner itself still sees every real call.
+# Row 3: every API path names THIS repository literally.
 #
-# The preprocessor is the load-bearing part of the two checks above, and a
-# preprocessor that silently stops matching turns them both into checks that
-# pass because they examined nothing. This row pins the count, so a stripping
-# change or a new call form is a FAILURE rather than a quiet loss of coverage.
-test_gh_invocation_scanner_sees_every_call() {
-    local count
-    count=$(gh_invocations_in_the_gate | grep -c . | tr -d ' ')
-    if [ "$count" = "10" ]; then
-        pass "the gh invocation scanner finds all 10 real calls in the gate"
+# The exports do not close this one. A literal path beats the environment, so
+# a call written against another literal repository would be pinned — at the
+# wrong target. Round 2's review found the previous version defined a constant
+# for this and then never used it.
+test_every_api_path_names_this_repository() {
+    local wrong
+    wrong=$(grep -n 'repos/' "$WRAPPER" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' \
+        | grep -v "$GATE_REPO_PATH" || true)
+    if [ -z "$wrong" ]; then
+        pass "every API path in the gate names this repository literally"
     else
-        fail "the gh invocation scanner found $count calls, expected 10 — the preprocessor or the call set changed"
+        fail "API path(s) not naming this repository: $(echo "$wrong" | tr '\n' ' ' | cut -c1-300)"
     fi
 }
 
-test_every_gh_call_in_the_gate_is_pinned
-test_gh_pin_is_adjacent_to_the_subcommand
+test_gate_exports_both_pins_before_using_gh
 test_no_ambient_repo_placeholder_in_the_gate
-test_gh_invocation_scanner_sees_every_call
+test_every_api_path_names_this_repository
 test_wrapper_blocks_unreadable_base_object
 test_wrapper_blocks_clearance_without_trees
 test_wrapper_blocks_empty_review_artifact

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -2126,60 +2126,6 @@ test_wrapper_blocks_moved_base
 test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
 
 # ---------------------------------------------------------------------------
-# THE GATE'S REPOSITORY AND HOST ARE PINNED BY CONSTRUCTION, AND THESE ROWS
-# CHECK THAT — THEY DO NOT PARSE SHELL.
-#
-# #607 round 3. Repository selection was AMBIENT: gh honours GH_REPO/GH_HOST
-# and git honours GIT_DIR/GIT_WORK_TREE, and `cd` binds neither. The reviewer
-# demonstrated it by running it — with GIT_DIR pointed elsewhere, every check
-# reported success while the request resolved to an unrelated repository.
-#
-# TWO ROUNDS OF REVIEW WERE SPENT ON THE WRONG SHAPE OF GUARD, and the second
-# round's defect was created by the first round's fix. That is worth recording
-# because it is the same signature that got #607's wrapper ruled WRONG_SHAPE.
-#
-#   Round 1 guarded by grepping for three fixed call prefixes and treating the
-#   substring `-R ` anywhere on the line as proof of a pin. It passed an
-#   unpinned call whose only `-R` sat in a trailing comment, and it could not
-#   see pipeline, backtick, direct or wrapped invocations at all.
-#
-#   Round 2 replaced that with a preprocessor: blank single-quoted strings,
-#   then double-quoted strings, then comments, and treat whatever `gh` survived
-#   as a real invocation. Round 2's review falsified it by execution. The line
-#   `X="$(gh pr list --state open)"` — an ordinary form — is erased ENTIRELY,
-#   because the command substitution sits inside the double quotes that get
-#   blanked. The call becomes invisible, and the count row added to catch
-#   exactly that cannot: an erased addition does not change the count.
-#
-# Both failures are the same failure. A text heuristic that errs toward
-# false-PASS is not a guard, it is a report that nothing was examined. So the
-# per-call-site policing is gone, and the property is held by construction
-# instead:
-#
-#     export GH_HOST=github.com
-#     export GH_REPO=BaseInfinity/claude-sdlc-harness
-#
-# The script's own exports beat the caller's environment, so EVERY gh call —
-# present, future, and in whatever syntactic form a scanner could not parse —
-# resolves to this repository on this host. Verified by execution under a
-# hostile outer environment, real gh 2.92.0, real network: with
-# GH_HOST=example.invalid GH_REPO=example.invalid/evil/wrong GIT_DIR=/tmp/nope.git
-# in the parent, the request still went to `Host: api.github.com` and returned
-# this repository's real ref.
-#
-# BOTH EXPORTS ARE LOAD-BEARING and that is not obvious. GH_REPO accepts a
-# HOST/OWNER/REPO form, so it looks like it should pin the host too. It does
-# not: with GH_REPO set correctly and a hostile GH_HOST, the request went to
-# `Host: example.invalid` on the `/api/v3/` enterprise path. GH_HOST wins.
-#
-# The per-call `-R` and `--hostname` flags stay in place as defense in depth.
-# Each layer covers a refactor that deletes the other.
-#
-# What remains below checks only things that can be read literally: two export
-# lines, a banned set of placeholder tokens, and a required literal path. Each
-# errs toward false-FAIL — a stray `:owner` in a trailing comment trips row 2,
-# which is a loud nuisance rather than a silent pass.
-# ---------------------------------------------------------------------------
 # FOUR GUARDS WERE WRITTEN FOR THE PIN AND ALL FOUR WERE DELETED. ONE ROW
 # SURVIVES, AND IT IS NOT THE ONE THAT PROVES THE PIN.
 #

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -2125,7 +2125,7 @@ test_wrapper_blocks_wrong_candidate_tree
 test_wrapper_blocks_moved_base
 test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
 
-# Test: every gh invocation in the gate pins the repository.
+# Test: every gh invocation in the gate pins BOTH the repository and the host.
 #
 # #607 round 3. Repository selection was AMBIENT: gh honours GH_REPO/GH_HOST
 # and git honours GIT_DIR/GIT_WORK_TREE, and `cd` binds neither. The reviewer
@@ -2136,20 +2136,168 @@ test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
 # site: a behavioural test can only cover the calls someone remembered to
 # write a fixture for, and the next unpinned call added to this file is
 # exactly the one no fixture exists for.
+#
+# ---------------------------------------------------------------------------
+# THE TWO SUBCOMMAND FAMILIES PIN DIFFERENTLY, AND THE FIRST VERSION OF THIS
+# CHECK DID NOT KNOW THAT.
+#
+# `gh pr` accepts `-R [HOST/]OWNER/REPO`, which pins host and repository
+# together. `gh api` DOES NOT ACCEPT `-R` AT ALL — gh 2.92.0 exits 1 with
+# "unknown shorthand flag: 'R'". Round 1 of this branch's review found four
+# `gh api` sites carrying `-R`, which would have made the gate abort before
+# reaching a single check. The suite was green over it because the fixture's
+# `gh` stub accepts any argv; the flag was never parsed by real gh.
+#
+# `gh api` is pinned by two things instead, and it needs both:
+#   * a LITERAL owner/repo in the path. `repos/:owner/:repo` and
+#     `repos/{owner}/{repo}` are placeholders gh resolves from the current
+#     directory or GH_REPO — which is the ambient channel being closed.
+#   * `--hostname github.com`. Verified by execution: with a literal path but
+#     GH_HOST=example.invalid, the request went to `Host: example.invalid`.
+#     A literal path alone pins the repository and leaves the HOST ambient.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS STRIPS STRINGS AND COMMENTS INSTEAD OF GREPPING FOR CALL PREFIXES.
+#
+# The first version matched three fixed prefixes — `$(gh `, `! gh ` and
+# `^MERGE_OUTPUT=$(gh `. Review enumerated what that misses: direct calls,
+# positive-condition calls, pipelines, backticks, env- and command-wrapped
+# calls, multiline continuations, and alternate whitespace. Every one of those
+# is an ordinary form a future maintainer would write, and each would be added
+# with a green suite.
+#
+# Worse, it decided "pinned" by looking for the SUBSTRING `-R ` anywhere on
+# the line, so an unpinned call passed whenever a trailing comment happened to
+# mention `-R`, and a call pinned at the WRONG repository passed unconditioned.
+#
+# So the file is preprocessed instead: single-quoted strings, double-quoted
+# strings and comments are blanked, and whatever `gh` survives is a real
+# invocation. That is what removes the prose mentions — "could not fetch PR
+# (gh error)", "gh pr merge did not succeed", "posted by the same gh token" —
+# without an allowlist that would have to grow with every new message. The
+# pin is then required ADJACENT to the subcommand rather than anywhere on the
+# line, which is what closes the trailing-comment hole: a comment cannot sit
+# between `gh pr merge` and its own flag.
+#
+# STATED LIMIT: the preprocessor is line-oriented, so a double-quoted string
+# spanning multiple lines leaves an unbalanced quote and the lines after it
+# are stripped on the wrong boundaries. The gate has no such string today and
+# the row below proves the scanner still finds all ten real calls, so a change
+# that introduced one would show up here as a count mismatch, not as silence.
+GATE_PIN='-R github.com/BaseInfinity/claude-sdlc-harness'
+GATE_REPO_PATH='repos/BaseInfinity/claude-sdlc-harness/'
+
+# Blank out quoted strings and comments so only real invocations remain.
+gh_invocations_in_the_gate() {
+    sed -e "s/'[^']*'/''/g" -e 's/"[^"]*"/""/g' -e 's/#.*$//' "$WRAPPER" \
+        | grep -nE '(^|[^[:alnum:]_./-])gh[[:space:]]' || true
+}
+
 test_every_gh_call_in_the_gate_is_pinned() {
-    local unpinned
-    unpinned=$(grep -n '\$(gh \|! gh \|^MERGE_OUTPUT=\$(gh ' "$WRAPPER" \
-        | grep -v '^[0-9]*:\s*#' \
-        | grep -v -- '-R ' || true)
-    if [ -z "$unpinned" ]; then
-        pass "every gh invocation in the gate pins the repository"
+    local calls bad="" line
+    calls=$(gh_invocations_in_the_gate)
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        case "$line" in
+            *"gh api"*)
+                # -R is not merely unnecessary here, it is fatal: real gh
+                # exits 1 before performing the request.
+                case "$line" in
+                    *"-R "*) bad="$bad
+gh api cannot take -R: $line" ;;
+                    *"gh api --hostname github.com "*) : ;;
+                    *) bad="$bad
+gh api not host-pinned: $line" ;;
+                esac
+                ;;
+            *"gh "*)
+                case "$line" in
+                    *"$GATE_PIN "*) : ;;
+                    *) bad="$bad
+gh call not repo-pinned: $line" ;;
+                esac
+                ;;
+        esac
+    done <<EOF
+$calls
+EOF
+    if [ -z "$bad" ]; then
+        pass "every gh invocation in the gate pins both the repository and the host"
     else
-        fail "unpinned gh call(s) in the gate: $(echo "$unpinned" | tr '\n' ' ' | cut -c1-200)"
+        fail "unpinned gh call(s) in the gate:$(echo "$bad" | tr '\n' ' ' | cut -c1-300)"
     fi
 }
 
+# Test: the pin is adjacent to the subcommand, not merely present on the line.
+#
+# Round 1 of review: the old check accepted a line whose only `-R ` was in a
+# trailing comment. Requiring adjacency is what makes that impossible — a
+# comment cannot appear between `gh pr merge` and its own flag.
+test_gh_pin_is_adjacent_to_the_subcommand() {
+    local calls bad="" line
+    calls=$(gh_invocations_in_the_gate)
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        case "$line" in
+            *"gh api"*) continue ;;
+        esac
+        case "$line" in
+            *"gh "*)
+                # gh pr <subcommand> -R <pin>, with nothing in between.
+                if echo "$line" | grep -qE "gh pr [a-z]+ -R github\.com/BaseInfinity/claude-sdlc-harness "; then
+                    :
+                else
+                    bad="$bad
+pin not adjacent to subcommand: $line"
+                fi
+                ;;
+        esac
+    done <<EOF
+$calls
+EOF
+    if [ -z "$bad" ]; then
+        pass "each gh pr pin sits immediately after its subcommand, not elsewhere on the line"
+    else
+        fail "pin not adjacent:$(echo "$bad" | tr '\n' ' ' | cut -c1-300)"
+    fi
+}
+
+# Test: no ambient repository placeholder survives in any gh api path.
+#
+# `:owner/:repo` and `{owner}/{repo}` are resolved by gh from the current
+# directory or GH_REPO. Leaving one in place keeps open the exact channel this
+# branch exists to close, and it cannot be seen by the pin check above because
+# a placeholder path is still a syntactically pinned-looking call.
+test_no_ambient_repo_placeholder_in_the_gate() {
+    local placeholders
+    placeholders=$(grep -nE 'repos/(:owner/:repo|\{owner\}/\{repo\})' "$WRAPPER" || true)
+    if [ -z "$placeholders" ]; then
+        pass "no ambient owner/repo placeholder remains in any gate API path"
+    else
+        fail "ambient placeholder(s) in the gate: $(echo "$placeholders" | tr '\n' ' ' | cut -c1-300)"
+    fi
+}
+
+# Test: the scanner itself still sees every real call.
+#
+# The preprocessor is the load-bearing part of the two checks above, and a
+# preprocessor that silently stops matching turns them both into checks that
+# pass because they examined nothing. This row pins the count, so a stripping
+# change or a new call form is a FAILURE rather than a quiet loss of coverage.
+test_gh_invocation_scanner_sees_every_call() {
+    local count
+    count=$(gh_invocations_in_the_gate | grep -c . | tr -d ' ')
+    if [ "$count" = "10" ]; then
+        pass "the gh invocation scanner finds all 10 real calls in the gate"
+    else
+        fail "the gh invocation scanner found $count calls, expected 10 — the preprocessor or the call set changed"
+    fi
+}
 
 test_every_gh_call_in_the_gate_is_pinned
+test_gh_pin_is_adjacent_to_the_subcommand
+test_no_ambient_repo_placeholder_in_the_gate
+test_gh_invocation_scanner_sees_every_call
 test_wrapper_blocks_unreadable_base_object
 test_wrapper_blocks_clearance_without_trees
 test_wrapper_blocks_empty_review_artifact

--- a/tests/test-merge-gate.sh
+++ b/tests/test-merge-gate.sh
@@ -381,15 +381,6 @@ CONFIG="$(dirname "$0")/../.gh-stub-config"
 # shellcheck disable=SC1090
 [ -f "$CONFIG" ] && source "$CONFIG"
 
-# Record the pin environment THIS invocation actually saw, before doing
-# anything else. Round 3's review ruled the source-level pin guards
-# WRONG_SHAPE; this log is what replaces them, because it observes the
-# runtime property the exports claim rather than the text that sets them.
-# `-` stands in for unset so an absent variable is distinguishable from an
-# empty one.
-printf '%s\n' "GH_PIN_ENV: host=${GH_HOST:--} repo=${GH_REPO:--} argv=$*" \
-    >> "$(dirname "$0")/../.gh-pin-env"
-
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
     # The wrapper now asks for changedFiles separately to prove the classified
     # path set is complete; answer with the fixture's real count.
@@ -2188,19 +2179,68 @@ test_wrapper_blocks_moved_server_base_with_stale_tracking_ref
 # lines, a banned set of placeholder tokens, and a required literal path. Each
 # errs toward false-FAIL — a stray `:owner` in a trailing comment trips row 2,
 # which is a loud nuisance rather than a silent pass.
-# Row 1: no ambient owner/repo placeholder token survives anywhere.
+# ---------------------------------------------------------------------------
+# FOUR GUARDS WERE WRITTEN FOR THE PIN AND ALL FOUR WERE DELETED. ONE ROW
+# SURVIVES, AND IT IS NOT THE ONE THAT PROVES THE PIN.
+#
+# The gate pins its forge target in `scripts/merge-pr.sh` itself, by exporting
+# GH_HOST and GH_REPO and by passing `-R` / `--hostname github.com` per call.
+# That is the fix, and it is verified by execution against real gh — see the
+# handoff. What kept failing review was every attempt to PROVE the property
+# from this file.
+#
+#   Round 1 took the substring `-R ` anywhere on a line as proof of a pin, so
+#   a trailing comment satisfied it, and it saw only three call prefixes.
+#
+#   Round 2 blanked quotes and comments first, then checked the surviving
+#   `gh` tokens. It ERASED real calls — `X="$(gh pr list)"` disappears with the
+#   quotes around it — and the count row added to catch that could not, since
+#   an erased addition leaves the count unchanged.
+#
+#   Round 3 checked that the exports precede the first call and that every
+#   `repos/` line names this repository. Ruled WRONG_SHAPE at confidence 99.
+#   Both rows passed a later `unset`, a per-command override, and a wrong
+#   literal target on a line that also mentioned the right one.
+#
+#   Round 4 replaced them with a BEHAVIOURAL row: the stub logged the pin
+#   environment each call saw, and the gate ran under a hostile environment.
+#   Ruled WRONG_SHAPE too. It passed vacuously when the gate exited after one
+#   correctly pinned call, and its unanchored grep accepted a wrong record
+#   whenever the expected substring appeared later in the argv it also logged.
+#
+# Four rewrites, four false-PASS failures, in four different mechanisms. The
+# stopping rule was written down before round 4 ran and is honoured here: the
+# guard is optional, the fix is not. A row that reports a property it does not
+# check is worse than no row, because the suite then certifies the absence of
+# evidence.
+#
+# WHAT IS ACTUALLY GUARDED, AND WHAT IS NOT:
+#
+#   Guarded here — no ambient placeholder token, below.
+#   Guarded elsewhere — `test_wrapper_merges_when_all_conditions_met` asserts
+#     the exact argv of the merge call, including its `-R`. That is one call
+#     site of ten, and it is an assertion about the merge command rather than
+#     about the pin as a property.
+#   NOT guarded — that a call added later carries the pin. Nothing in this
+#     file establishes that, and four attempts to make something establish it
+#     were each wrong in a way that read as green. It rests on the exports in
+#     `scripts/merge-pr.sh`, which apply to any call that does not override
+#     them, and on review.
+#
+# Do not add a fifth guard without a way to make it fail first on a real
+# defect. That is what all four lacked.
+
+# The one surviving row: no ambient owner/repo placeholder token.
 #
 # `:owner`, `:repo`, `{owner}` and `{repo}` are resolved by gh from the current
 # directory or GH_REPO. Round 2's review found an earlier version enumerated
 # only the two matched PAIRS, so the mixed form `repos/{owner}/:repo` was
 # invisible — and gh resolves that form perfectly well, verified by running it.
-# Banning the TOKENS rather than the pairs is what removes the combinatorics.
+# Banning the TOKENS rather than the pairs removes the combinatorics.
 #
-# THIS IS THE ONE SOURCE-LEVEL ROW THAT SURVIVED ROUND 3, and the reason it did
-# is the reason the others did not: it errs toward false-FAIL. A stray `:repo`
-# in a trailing comment fails this row loudly. That is a nuisance. Every row
-# deleted below erred the other way, and a guard that errs toward false-PASS is
-# not a guard, it is a report that nothing was examined.
+# THIS ROW SURVIVED BECAUSE IT ERRS TOWARD FALSE-FAIL. A stray `:repo` in a
+# trailing comment fails it loudly. That is a nuisance. All four deleted rows
+# erred the other way.
 test_no_ambient_repo_placeholder_in_the_gate() {
     local placeholders
     placeholders=$(grep -nE ':owner|:repo|\{owner\}|\{repo\}' "$WRAPPER" \
@@ -2212,73 +2252,7 @@ test_no_ambient_repo_placeholder_in_the_gate() {
     fi
 }
 
-# Row 2: BEHAVIOURAL. Every gh invocation the gate actually makes sees the pin.
-#
-# ---------------------------------------------------------------------------
-# THREE SOURCE-LEVEL GUARDS WERE WRITTEN FOR THIS PROPERTY AND ALL THREE WERE
-# WRONG. Round 3's review ruled the genre WRONG_SHAPE at confidence 99.
-#
-#   Round 1 grepped for three fixed call prefixes and took the substring `-R `
-#   anywhere on the line as proof of a pin. A trailing comment satisfied it.
-#
-#   Round 2 blanked quoted strings and comments first, then checked whatever
-#   `gh` survived. It ERASED real calls: `X="$(gh pr list)"` disappears with
-#   the quotes around it, and the count row added to catch that cannot, since
-#   an erased addition leaves the count unchanged.
-#
-#   Round 3 checked that the exports appear before the first gh use, and that
-#   every `repos/` line names this repository. Both still passed on inputs
-#   that break the property: a later `unset GH_REPO`, a per-command
-#   `GH_REPO=evil gh …` override, a path-qualified `/usr/bin/gh`, and a wrong
-#   literal target whose line happens to also mention the right one.
-#
-# Each rewrite reproduced the previous one's failure mode in new clothes,
-# because the thing being checked — "what repository will this call reach" —
-# is a RUNTIME property, and shell source text does not determine it. So this
-# row stops reading the file and runs the gate instead.
-#
-# The stub records `GH_HOST` and `GH_REPO` as each invocation actually saw
-# them. The fixture is then run with a HOSTILE environment exported around the
-# wrapper, which is the condition the exports exist for. Every recorded
-# invocation must have seen the pinned values, or the property is broken —
-# however the source happens to be written.
-#
-# This catches what the source-level rows could not: an export deleted, an
-# export unset later in the file, and a per-command override on a single call.
-#
-# STATED LIMIT, and it is shared with every other row in this suite: the stub
-# is reached through PATH, so an invocation written as `/usr/bin/gh` bypasses
-# it and this row cannot see that call at all. Nothing in this file can. It is
-# a limit of stub-based testing, not of this row's design.
-test_every_gh_invocation_sees_the_pin_at_runtime() {
-    local tmpdir out exit_code seen bad
-    tmpdir=$(setup_wrapper_fixture)
-    write_clearance "$tmpdir" 123 "CERTIFIED" 2 "$(cat "$tmpdir/.fixture-sha")" ".reviews/some-review.md"
-    echo "content" > "$tmpdir/.reviews/some-review.md"
-    rm -f "$tmpdir/.gh-pin-env"
-
-    # The hostile environment is the whole point of the row. If the gate's own
-    # exports are missing or overridden, these are the values gh would see.
-    out=$(cd "$tmpdir" && PATH="$tmpdir/bin:$PATH" \
-        GH_HOST=example.invalid \
-        GH_REPO=example.invalid/evil/wrong \
-        "$WRAPPER" 123 2>&1) && exit_code=0 || exit_code=$?
-
-    seen=$(cat "$tmpdir/.gh-pin-env" 2>/dev/null || true)
-    bad=$(printf '%s\n' "$seen" | grep -v 'host=github\.com repo=BaseInfinity/claude-sdlc-harness ' || true)
-    rm -rf "$tmpdir"
-
-    if [ -z "$seen" ]; then
-        fail "no gh invocation was recorded at all — this row proved nothing (wrapper exit=$exit_code)"
-    elif [ -n "$bad" ]; then
-        fail "gh invocation(s) ran without the pin despite the gate's exports: $(echo "$bad" | tr '\n' ' ' | cut -c1-300)"
-    else
-        pass "every gh invocation the gate makes sees the pinned host and repository, even under a hostile environment"
-    fi
-}
-
 test_no_ambient_repo_placeholder_in_the_gate
-test_every_gh_invocation_sees_the_pin_at_runtime
 test_wrapper_blocks_unreadable_base_object
 test_wrapper_blocks_clearance_without_trees
 test_wrapper_blocks_empty_review_artifact


### PR DESCRIPTION
`scripts/merge-pr.sh` resolved its repository ambiently. Ten `gh` invocations
took owner/repo from whatever the environment said, so `GH_REPO`, `GH_HOST`,
`GIT_DIR` or `GIT_WORK_TREE` could point the merge gate at a different
repository than the one it believed it was gating.

Closed by construction: `export GH_HOST=github.com` and
`export GH_REPO=BaseInfinity/claude-sdlc-harness` after `set -u`, with the
per-call `-R` / `--hostname` flags kept as a second layer.

`gh api` rejects `-R` outright — gh 2.92.0 exits with
`unknown shorthand flag: 'R'`. Four call sites carried it and would have
aborted the gate before its first check. The suite was green at 125/0 the
whole time because the fixture's `gh` stub accepts any argv, so the flag never
reached real gh. Those four now use a literal path plus `--hostname github.com`.

Verified by execution against real gh and real github.com under
`GH_HOST=example.invalid GH_REPO=example.invalid/evil/wrong GIT_DIR=/tmp/nope.git`.
Both exports are load-bearing: `GH_REPO` alone loses the host and the call
lands on `/api/v3/`.

Four successive guards for the pin property were written and all four deleted —
each reported a property it did not actually check. What survives is one
placeholder-token check, and a comment block recording the four and why, so
nobody writes a fifth without a way to make it fail first. Everything the pin
does not prove is written down as unproven: `--paginate` follows server Link
headers so only the initial URL is pinned, and `GIT_DIR` still redirects the
gate's own git calls.

Seven review rounds, two `WRONG_SHAPE` rulings. Full `ci.yml` list: 81/81.
Filed along the way: #680, #681, #682. Relates to #679.
