### PR TITLE
docs: correct the stale #607 entry and write the post-merge save point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ and a false protection claim is worse than none — it is relied on:
 
 | Setting | Live value |
 |---|---|
-| Required status checks | `validate`, strict |
+| Required status checks | `validate`, strict, pinned to app_id 15368 (GitHub Actions) |
 | Required approving reviews | **none** |
 | `enforce_admins` | **false** |
 | `allow_force_pushes` | false — force pushes are blocked |
@@ -177,8 +177,11 @@ and a false protection claim is worse than none — it is relied on:
 | `allow_fork_syncing` | false |
 | Rulesets | **none** |
 
-That is every field the protection endpoint returns, so the rows above are the
-whole rule and not a selection from it.
+Those are the protection endpoint's own fields, so the rows are the whole rule
+and not a selection from it. The status-check row folds in one subfield:
+`required_status_checks.checks[0].app_id` is 15368, which pins `validate` to
+GitHub Actions, so another app cannot satisfy the check by reporting a context
+of the same name.
 
 **`main` IS a protected branch, and the protection is real but narrow.** Two
 rows bind everyone: GitHub groups `allow_force_pushes` and `allow_deletions`
@@ -190,11 +193,9 @@ Everything else is bypassable by an admin, because `enforce_admins` is false —
 including `validate`, the only gate on the CONTENT of a change. And no review
 of any kind is required to merge.
 
-Getting this right took four wrong versions in one branch: it overclaimed,
-then the correction underclaimed by calling `validate` the only protection,
-then a draft called the repo unprotected, then one said an admin bypasses all
-of it. If you edit this block, read the live API first and check the claim in
-both directions.
+If you edit this block, read the live API first, and check the claim in both
+directions — this section has been wrong by overclaiming and by underclaiming,
+in roughly equal measure.
 
 The real enforcement lives in `scripts/merge-pr.sh`, which is repo-local and
 voluntary — it is not a forge gate and cannot stop a direct push. #679 tracks

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,53 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > **v2.0.0's terminal gate is #545, not issue closure.** The major release is authorized when the maintainer has personally consumed the harness in another repo and it worked. Every other issue closing is necessary and not sufficient.
 >
-> ### Last save point — 2026-08-18, session handoff
+> ### Last save point — 2026-08-22
+>
+> **Nothing is in flight. `main` is clean and both branches from 2026-08-22 are
+> merged.** #683 pinned the repository the merge gate talks to; #684 replaced
+> `CLAUDE.md`'s false branch-protection claims with the live settings.
+>
+> **START HERE**
+>
+> **1. Take the first open, unblocked issue in #593 Rung 1**, per the DO THIS NOW
+> block at the top of this file. That block is the queue; this one is context.
+>
+> **2. Do not delete these two branches.** `chore/allowlist-merge-script` is
+> preserved design evidence for the #607 ruling.
+> `docs/correct-branch-protection-claims` is preserved for a different reason:
+> both merges were squashes, so a block of ROADMAP text written on it and then
+> deliberately reverted exists only in its commits. Delete it once nothing needs
+> that history.
+>
+> **3. `.reviews/handoff.json` is gitignored and branch-bound.** The codex gate
+> refuses a commit when its `branch` field names a different branch. Retarget it;
+> never bypass it.
+>
+> **4. Run the whole `ci.yml` suite list before posting any clearance.** Not the
+> table in `CLAUDE.md` — `.github/workflows/ci.yml` is the authority, and it names
+> 82 test steps. `tests/e2e/run-simulation.sh` is the one to exclude when running
+> locally: it shells out to `claude --print` and burns live quota, while CI runs it
+> without a claude binary in fixture-validation mode. So 81 locally.
+>
+> **Rules this file must obey, learned by breaking them on 2026-08-22.**
+>
+> **A save point must not describe its own review state.** Three consecutive
+> review rounds died on that: the round that certifies the branch falsifies the
+> sentence, so it needs re-editing after every round and twice was not. Round
+> state lives in `.reviews/handoff.json`, which is where it can be true. This
+> block records the standing plan and nothing about how it was reviewed.
+>
+> **A save point's steps must be executable in the order written.** The previous
+> version told the reader to post clearances and merge at step 3 and to push at
+> step 4, when nothing was pushed yet. Push, then PR, then clearances, then merge.
+>
+> **Carried forward, both from #684's round 8 and both still open:** `CLAUDE.md`'s
+> status-check row omits `required_status_checks.checks[0].app_id`, and the
+> four-version history in that section reads as session narration rather than
+> guidance. Both are fixed on this branch — if you are reading this on `main`,
+> they are done.
+>
+> ### Prior save point — 2026-08-18, session handoff
 >
 > Written so a cold session resumes without reading a transcript. Issue numbers only, because the tracker owns PR state (#482): **milestone v1.99.2** is complete (**#579**, **#544**, **#499**) and closed on GitHub.
 >
@@ -44,7 +90,7 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > **3. Every gate rejection on #670 was legitimate.** Five of them: verdict token, short SHA instead of the full 40 chars, a clearance file still describing the pre-rebase base, a branch one commit behind `main`, and pending CI. None was the gate being wrong, and each was fixed by satisfying it. **A rebase kills a clearance, and that is correct** — the fix is a fresh confirm leg asking the one question a byte-identical patch can hide (does the new base interact with the change?), not a carried-over verdict.
 >
-> **#607 is open and should be closed.** Its premise was falsified during this session: `merge-pr.sh` runs fine from a clean `main` worktree with the entry absent, so "PROVEN NEEDED" was false. The falsification is posted on the issue. Closing it is the maintainer's call.
+> **#607 is CLOSED as of 2026-08-20, and not for the reason the line above this one used to give.** The 2026-08-18 falsification was itself wrong — it generalised one successful trial into "does not reproduce", and both seats agreed that was n=1 reasoning. #607 reopened on fresh evidence, ran four review rounds, and closed on a **design ruling**: merge authority in a mutable, allowlisted, environment-sensitive local script would have had to authenticate itself, its repository, git's work tree, git's object database, the forge target, and its own future edits, all to do the narrow job of restricting argv. Sol ruled STOP AND REDESIGN and Fable ratified it. The branch `chore/allowlist-merge-script` is preserved as design evidence and **must not be deleted**. The `-R` repository pinning was split out because it is independently correct, and it shipped separately in #683.
 >
 > **v2.0.0 is a delivery vehicle now, not a pile of issues (restructured 2026-08-18).** No new milestone was created — **v2.0.0 — Consumer Safety Repairs** already existed and a second major-release milestone would have forked the queue. What it lacked was the release itself: every issue on it changed the harness, none of them shipped one. **#673** now covers the cut — version bump, CHANGELOG, `git tag v2.0.0 && git push origin v2.0.0`, `npm view` verification from outside, and the plugin-surface checks `CLAUDE.md` requires. **Merging publishes nothing**; `release.yml` fires on the tag push. **#638** (Homebrew 3 months stale, gh extension 4 — a 2.0 shipping to one channel is a 2.0 most consumers never see) and **#622** (the post-mortem runs or is explicitly waived) are attached for the same reason.
 >

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,27 +24,29 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 > merged.** #683 pinned the repository the merge gate talks to; #684 replaced
 > `CLAUDE.md`'s false branch-protection claims with the live settings.
 >
-> **START HERE**
+> **START HERE — in this order, because steps 1 to 3 are prerequisites of the
+> work in step 4, not follow-ups to it.**
 >
-> **1. Take the first open, unblocked issue in #593 Rung 1**, per the DO THIS NOW
-> block at the top of this file. That block is the queue; this one is context.
+> **1. Retarget `.reviews/handoff.json` before your first commit.** It is
+> gitignored and branch-bound, and the codex gate refuses a commit when its
+> `branch` field names a branch you are not on. Retarget it; never bypass it.
 >
-> **2. Do not delete these two branches.** `chore/allowlist-merge-script` is
-> preserved design evidence for the #607 ruling.
-> `docs/correct-branch-protection-claims` is preserved for a different reason:
-> both merges were squashes, so a block of ROADMAP text written on it and then
-> deliberately reverted exists only in its commits. Delete it once nothing needs
-> that history.
+> **2. Know which suite list you owe before you owe it.**
+> `.github/workflows/ci.yml` is the authority on what must pass — not the table
+> in `CLAUDE.md` — and it names 82 test steps. Run the whole list before posting
+> any clearance. `tests/e2e/run-simulation.sh` is the one to exclude locally: it
+> shells out to `claude --print` and burns live quota, while CI runs it without a
+> claude binary in fixture-validation mode. So 81 locally, 82 in CI.
 >
-> **3. `.reviews/handoff.json` is gitignored and branch-bound.** The codex gate
-> refuses a commit when its `branch` field names a different branch. Retarget it;
-> never bypass it.
+> **3. Do not delete two branches.** `chore/allowlist-merge-script` is preserved
+> design evidence for the #607 ruling. `docs/correct-branch-protection-claims` is
+> preserved for a different reason: it merged as a squash, so a block of ROADMAP
+> text written on it and then deliberately reverted exists only in its own
+> commits. Delete it once nothing needs that history.
 >
-> **4. Run the whole `ci.yml` suite list before posting any clearance.** Not the
-> table in `CLAUDE.md` — `.github/workflows/ci.yml` is the authority, and it names
-> 82 test steps. `tests/e2e/run-simulation.sh` is the one to exclude when running
-> locally: it shells out to `claude --print` and burns live quota, while CI runs it
-> without a claude binary in fixture-validation mode. So 81 locally.
+> **4. Then take the first open, unblocked issue in #593 Rung 1**, per the DO
+> THIS NOW block at the top of this file. That block is the queue and it runs
+> through to a merged PR; this one is the standing context that block assumes.
 >
 > **Rules this file must obey, learned by breaking them on 2026-08-22.**
 >
@@ -57,12 +59,6 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 > **A save point's steps must be executable in the order written.** The previous
 > version told the reader to post clearances and merge at step 3 and to push at
 > step 4, when nothing was pushed yet. Push, then PR, then clearances, then merge.
->
-> **Carried forward, both from #684's round 8 and both still open:** `CLAUDE.md`'s
-> status-check row omits `required_status_checks.checks[0].app_id`, and the
-> four-version history in that section reads as session narration rather than
-> guidance. Both are fixed on this branch — if you are reading this on `main`,
-> they are done.
 >
 > ### Prior save point — 2026-08-18, session handoff
 >
@@ -90,7 +86,7 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > **3. Every gate rejection on #670 was legitimate.** Five of them: verdict token, short SHA instead of the full 40 chars, a clearance file still describing the pre-rebase base, a branch one commit behind `main`, and pending CI. None was the gate being wrong, and each was fixed by satisfying it. **A rebase kills a clearance, and that is correct** — the fix is a fresh confirm leg asking the one question a byte-identical patch can hide (does the new base interact with the change?), not a carried-over verdict.
 >
-> **#607 is CLOSED as of 2026-08-20, and not for the reason the line above this one used to give.** The 2026-08-18 falsification was itself wrong — it generalised one successful trial into "does not reproduce", and both seats agreed that was n=1 reasoning. #607 reopened on fresh evidence, ran four review rounds, and closed on a **design ruling**: merge authority in a mutable, allowlisted, environment-sensitive local script would have had to authenticate itself, its repository, git's work tree, git's object database, the forge target, and its own future edits, all to do the narrow job of restricting argv. Sol ruled STOP AND REDESIGN and Fable ratified it. The branch `chore/allowlist-merge-script` is preserved as design evidence and **must not be deleted**. The `-R` repository pinning was split out because it is independently correct, and it shipped separately in #683.
+> **#607 is CLOSED as of 2026-08-20, and not for the reason this file gave until now.** The 2026-08-18 falsification was itself wrong — it generalised one successful trial into "does not reproduce", and both seats agreed that was n=1 reasoning. #607 reopened on fresh evidence, ran four review rounds, and closed on a **design ruling**: merge authority in a mutable, allowlisted, environment-sensitive local script would have had to authenticate itself, its repository, git's work tree, git's object database, the forge target, and its own future edits, all to do the narrow job of restricting argv. Sol ruled STOP AND REDESIGN and Fable ratified it. The branch `chore/allowlist-merge-script` is preserved as design evidence and **must not be deleted**. The `-R` repository pinning was split out because it is independently correct, and it shipped separately in #683.
 >
 > **v2.0.0 is a delivery vehicle now, not a pile of issues (restructured 2026-08-18).** No new milestone was created — **v2.0.0 — Consumer Safety Repairs** already existed and a second major-release milestone would have forked the queue. What it lacked was the release itself: every issue on it changed the harness, none of them shipped one. **#673** now covers the cut — version bump, CHANGELOG, `git tag v2.0.0 && git push origin v2.0.0`, `npm view` verification from outside, and the plugin-surface checks `CLAUDE.md` requires. **Merging publishes nothing**; `release.yml` fires on the tag push. **#638** (Homebrew 3 months stale, gh extension 4 — a 2.0 shipping to one channel is a 2.0 most consumers never see) and **#622** (the post-mortem runs or is explicitly waived) are attached for the same reason.
 >

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,46 +25,10 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 > settings. For what is open or in flight, read the tracker — this file does not
 > restate PR state (#482), and any count written here is wrong by the next merge.
 >
-> **START HERE.** This is the order the work actually happens in; each step
-> depends on the one before it.
->
-> **1. Take the first open, unblocked issue in #593 Rung 1.** The DO THIS NOW
-> block at the top of this file is the queue and owns the order — read it there.
-> Implement only that issue's acceptance criteria; anything else you notice
-> becomes a new issue.
->
-> **2. Branch, then retarget `.reviews/handoff.json` before your first commit.**
-> It is gitignored and branch-bound, and the codex gate refuses a commit when its
-> `branch` field names a branch you are not on. Retarget it; never bypass it.
->
-> **3. Run the whole `ci.yml` suite list before posting any clearance.**
-> `.github/workflows/ci.yml` is the authority on what must pass, not the table in
-> `CLAUDE.md`, and it names 82 test steps. `tests/e2e/run-simulation.sh` is the
-> one to exclude locally: it shells out to `claude --print` and burns live quota,
-> while CI runs it without a claude binary in fixture-validation mode. So 81
-> locally, 82 in CI.
->
-> **4. Push, open the PR, post clearances bound to the head SHA, then merge** —
-> in that order. A clearance names a commit, so it has to exist on the remote
-> first, and a rebase kills it.
->
-> **Standing, not a step: do not delete two branches.**
-> `chore/allowlist-merge-script` is preserved design evidence for the #607
-> ruling. `docs/correct-branch-protection-claims` merged as a squash, so a block
-> of ROADMAP text written on it and then deliberately reverted exists only in its
-> own commits. Delete it once nothing needs that history.
->
-> **Rules this file must obey, learned by breaking them on 2026-08-22.**
->
-> **A save point must not describe its own review state.** Three consecutive
-> review rounds died on that: the round that certifies the branch falsifies the
-> sentence, so it needs re-editing after every round and twice was not. Round
-> state lives in `.reviews/handoff.json`, which is where it can be true. This
-> block records the standing plan and nothing about how it was reviewed.
->
-> **A save point's steps must be executable in the order written.** The previous
-> version told the reader to post clearances and merge at step 3 and to push at
-> step 4, when nothing was pushed yet. Push, then PR, then clearances, then merge.
+> **Standing: do not delete `docs/correct-branch-protection-claims`.** It merged
+> as a squash, so a block of ROADMAP text written on it and then deliberately
+> reverted exists only in its own commits. Delete it once nothing needs that
+> history.
 >
 > ### Prior save point — 2026-08-18, session handoff
 >

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,33 +20,39 @@ Cold-open pointer: if you're picking this repo back up and don't know where to l
 >
 > ### Last save point — 2026-08-22
 >
-> **Nothing is in flight. `main` is clean and both branches from 2026-08-22 are
-> merged.** #683 pinned the repository the merge gate talks to; #684 replaced
-> `CLAUDE.md`'s false branch-protection claims with the live settings.
+> **Shipped 2026-08-22:** #683 pinned the repository the merge gate talks to,
+> and #684 replaced `CLAUDE.md`'s false branch-protection claims with the live
+> settings. For what is open or in flight, read the tracker — this file does not
+> restate PR state (#482), and any count written here is wrong by the next merge.
 >
-> **START HERE — in this order, because steps 1 to 3 are prerequisites of the
-> work in step 4, not follow-ups to it.**
+> **START HERE.** This is the order the work actually happens in; each step
+> depends on the one before it.
 >
-> **1. Retarget `.reviews/handoff.json` before your first commit.** It is
-> gitignored and branch-bound, and the codex gate refuses a commit when its
+> **1. Take the first open, unblocked issue in #593 Rung 1.** The DO THIS NOW
+> block at the top of this file is the queue and owns the order — read it there.
+> Implement only that issue's acceptance criteria; anything else you notice
+> becomes a new issue.
+>
+> **2. Branch, then retarget `.reviews/handoff.json` before your first commit.**
+> It is gitignored and branch-bound, and the codex gate refuses a commit when its
 > `branch` field names a branch you are not on. Retarget it; never bypass it.
 >
-> **2. Know which suite list you owe before you owe it.**
-> `.github/workflows/ci.yml` is the authority on what must pass — not the table
-> in `CLAUDE.md` — and it names 82 test steps. Run the whole list before posting
-> any clearance. `tests/e2e/run-simulation.sh` is the one to exclude locally: it
-> shells out to `claude --print` and burns live quota, while CI runs it without a
-> claude binary in fixture-validation mode. So 81 locally, 82 in CI.
+> **3. Run the whole `ci.yml` suite list before posting any clearance.**
+> `.github/workflows/ci.yml` is the authority on what must pass, not the table in
+> `CLAUDE.md`, and it names 82 test steps. `tests/e2e/run-simulation.sh` is the
+> one to exclude locally: it shells out to `claude --print` and burns live quota,
+> while CI runs it without a claude binary in fixture-validation mode. So 81
+> locally, 82 in CI.
 >
-> **3. Do not delete two branches.** `chore/allowlist-merge-script` is preserved
-> design evidence for the #607 ruling. `docs/correct-branch-protection-claims` is
-> preserved for a different reason: it merged as a squash, so a block of ROADMAP
-> text written on it and then deliberately reverted exists only in its own
-> commits. Delete it once nothing needs that history.
+> **4. Push, open the PR, post clearances bound to the head SHA, then merge** —
+> in that order. A clearance names a commit, so it has to exist on the remote
+> first, and a rebase kills it.
 >
-> **4. Then take the first open, unblocked issue in #593 Rung 1**, per the DO
-> THIS NOW block at the top of this file. That block is the queue and it runs
-> through to a merged PR; this one is the standing context that block assumes.
+> **Standing, not a step: do not delete two branches.**
+> `chore/allowlist-merge-script` is preserved design evidence for the #607
+> ruling. `docs/correct-branch-protection-claims` merged as a squash, so a block
+> of ROADMAP text written on it and then deliberately reverted exists only in its
+> own commits. Delete it once nothing needs that history.
 >
 > **Rules this file must obey, learned by breaking them on 2026-08-22.**
 >


### PR DESCRIPTION
Two corrections main was carrying, plus the save point that #684's scope revert
made mandatory.

**The stale #607 entry.** ROADMAP said "#607 is open and should be closed",
resting on a falsification recorded on 2026-08-18. That falsification was
itself wrong — it generalised one successful trial into "does not reproduce".
#607 reopened on fresh evidence, ran four review rounds, and closed on
2026-08-20 on a design ruling. The corrected paragraph existed in a commit that
#684 discarded when it reverted ROADMAP to restore its scope card, so it lands
here.

**The two findings #684 certified while holding.** `CLAUDE.md`'s status-check
row omitted `required_status_checks.checks[0].app_id`; it now names 15368, read
from the live API, and says what pinning it buys — another app cannot satisfy
`validate` by reporting a context of the same name. And the four-version
history of that section is cut to the instruction that outlives it.

**The save point is four past-tense items.** It started as an ordered START
HERE list and a block of rules about writing save points. Round 3 ruled that
`WRONG_SHAPE` with disposition DELETE, and both seats agreed: DO THIS NOW
already owns the queue and #580 already ruled that a copied sequence goes
stale, so three rounds of reordering could not have worked — ordering was never
the defect, existing was. A save point that legislates how to write save points
is narrating its own review, and the paragraph asserting it said nothing about
its own review state was its own counterexample.

Relocating those rules into `CLAUDE.md` was considered and rejected: the ruling
was DELETE, and it would have widened the scope card and reopened review on a
file that took zero findings in four rounds.

Four rounds. Full `ci.yml` list: 81/81. Relates to #607 and #684.
