### PR TITLE
docs(wizard): stop Step 0.0 from locking new consumers out of their own main

### DIFF
--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1456,7 +1456,18 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 
 ### Step 0.0: Enable Branch Protection (CRITICAL)
 
-**Before setting up SDLC, protect your main branch.** This is non-negotiable for teams and highly recommended for solo developers.
+**Protect your main branch early — but not before CI can report.** This is non-negotiable for teams and highly recommended for solo developers.
+
+> **Do this in order, whichever method you use below.** A required status check
+> that has never reported blocks every merge — GitHub shows it as *Expected —
+> waiting for status* — and *Include administrators* removes the override that
+> would let you merge anyway. Protect a repo that has no CI yet and you lock
+> yourself out of your own `main`.
+>
+> 1. Add the workflow that produces `validate` and push it on a branch.
+> 2. Open a PR and watch `validate` go green at least once, so you know the
+>    check name exists and reports.
+> 3. **Then** apply protection — UI or CLI, both below.
 
 **Why this matters:**
 - SDLC enforcement is only as strong as your merge protection
@@ -1492,18 +1503,8 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 
 > **Note (ROADMAP #212 Option 1, April 2026):** We no longer require `e2e-quick-check` as a blocking check. It burned Anthropic API credits on every PR, and branch protection pinned to GitHub Actions made local-maintainer check-run satisfaction impossible. E2E now runs advisory-only via `tests/e2e/local-shepherd.sh` on the maintainer's Max subscription. See `ROADMAP.md` #212 for the full rationale.
 
-**Order matters. Do not run this first.** A required status check that has
-never reported blocks every merge — GitHub shows it as *Expected — waiting for
-status* — and `enforce_admins: true` removes the override that would let you
-merge anyway. Apply protection to a repo with no CI yet and you lock yourself
-out of your own `main`.
-
-1. Add the workflow that produces `validate` and push it on a branch.
-2. Open a PR and watch `validate` go green at least once, so the check name
-   exists and you know it reports.
-3. Then run the recipe below.
-
-**How to enable (CLI — solo dev):**
+**How to enable (CLI — solo dev):** *(the ordering rule at the top of Step 0.0
+applies — `validate` must have reported green once before you run this)*
 ```bash
 gh api repos/OWNER/REPO/branches/main/protection --method PUT --input - << 'EOF'
 {

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1492,6 +1492,17 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 
 > **Note (ROADMAP #212 Option 1, April 2026):** We no longer require `e2e-quick-check` as a blocking check. It burned Anthropic API credits on every PR, and branch protection pinned to GitHub Actions made local-maintainer check-run satisfaction impossible. E2E now runs advisory-only via `tests/e2e/local-shepherd.sh` on the maintainer's Max subscription. See `ROADMAP.md` #212 for the full rationale.
 
+**Order matters. Do not run this first.** A required status check that has
+never reported blocks every merge — GitHub shows it as *Expected — waiting for
+status* — and `enforce_admins: true` removes the override that would let you
+merge anyway. Apply protection to a repo with no CI yet and you lock yourself
+out of your own `main`.
+
+1. Add the workflow that produces `validate` and push it on a branch.
+2. Open a PR and watch `validate` go green at least once, so the check name
+   exists and you know it reports.
+3. Then run the recipe below.
+
 **How to enable (CLI — solo dev):**
 ```bash
 gh api repos/OWNER/REPO/branches/main/protection --method PUT --input - << 'EOF'
@@ -1510,12 +1521,12 @@ EOF
 ```
 
 **Why `enforce_admins: true` for a solo dev.** The usual reason to leave it off
-is that it locks the only admin out. That is true when a review is required —
-GitHub refuses self-approval, so an admin with `required_approving_review_count:
-1` and nobody else around cannot merge anything. With **0** approvals there is
-nothing to be locked out of: you owe a green `validate` and an up-to-date
-branch, which you were waiting for anyway. This repo turned `enforce_admins` on
-in August 2026 with approvals at 0 and nothing locked up.
+is that it locks the only admin out. That reason is about *approvals*: GitHub
+refuses self-approval, so an admin with `required_approving_review_count: 1` and
+nobody else around cannot merge anything. At **0** approvals that particular
+trap is gone — what remains is a green `validate` and an up-to-date branch,
+which you were waiting for anyway. It is still a real lock if the check cannot
+report, which is what the ordering above is for.
 
 **Why `required_approving_review_count: 0` and not `null`.** `null` does not
 mean "a PR with no approvals" — it means **no pull request is required at
@@ -1530,6 +1541,12 @@ direct push to `main`. A commit that already carries a green `validate` lands �
 push a branch, let CI run, then push that same SHA to `main`. Check runs attach
 to commits rather than branches. Only a *fresh* commit is rejected. Requiring
 the pull request is what closes that, not `enforce_admins`.
+
+**And a green `validate` is not a trustworthy signal on its own.** The check is
+produced by a workflow file that lives in the repository, so a branch under
+review can change what `validate` does — including making it pass. Branch
+protection enforces that the check *reported success*; it cannot enforce what
+the check measured. Treat protection as a floor, not as review.
 
 **Changing one field later:** `PUT .../protection` **replaces the entire
 protection object**, so re-running one of these recipes to adjust a single

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1479,20 +1479,20 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| Require pull request before merging | ✓ Enabled | All changes go through PR review |
+| Require a pull request before merging | ✓ Enabled | All changes go through PR review |
 | Require approvals | **0 (none)** | No one else to approve — CI is your gate |
-| Require status checks to pass | ✓ Enabled | CI must be green |
-| Require branches to be up to date | ✓ Enabled | No stale merges |
+| Require status checks to pass before merging | ✓ Enabled | CI must be green |
+| Require branches to be up to date before merging | ✓ Enabled | No stale merges |
 | Do not allow bypassing the above settings | **✓ Enabled** | Safe at 0 approvals — but set CI up first, see below |
 
 **Team Settings (2+ developers):**
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| Require pull request before merging | ✓ Enabled | All changes go through PR review |
+| Require a pull request before merging | ✓ Enabled | All changes go through PR review |
 | Require approvals | 1+ (your choice) | Human must approve before merge |
-| Require status checks to pass | ✓ Enabled | CI must be green |
-| Require branches to be up to date | ✓ Enabled | No stale merges |
+| Require status checks to pass before merging | ✓ Enabled | CI must be green |
+| Require branches to be up to date before merging | ✓ Enabled | No stale merges |
 | Do not allow bypassing the above settings | ✓ Enabled | No one bypasses the rules |
 
 **How to enable (UI):**
@@ -1500,7 +1500,7 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 2. Branch name pattern: `main` (or `master`)
 3. Enable the settings above (solo or team, as appropriate)
 4. Add required status checks: `validate` (E2E is advisory — see note below)
-5. Save changes
+5. Click **Create** (the `Add rule` flow ends in `Create`; `Save changes` is the edit flow)
 
 > **Note (ROADMAP #212 Option 1, April 2026):** We no longer require `e2e-quick-check` as a blocking check. It burned Anthropic API credits on every PR, and branch protection pinned to GitHub Actions made local-maintainer check-run satisfaction impossible. E2E now runs advisory-only via `tests/e2e/local-shepherd.sh` on the maintainer's Max subscription. See `ROADMAP.md` #212 for the full rationale.
 
@@ -1582,7 +1582,7 @@ EOF
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| Require CODEOWNERS review | ✓ Enabled | Specific people must approve |
+| Require review from Code Owners | ✓ Enabled | Specific people must approve |
 
 **CODEOWNERS file (teams only):**
 Create `.github/CODEOWNERS`:

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1460,9 +1460,10 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 
 > **Do this in order, whichever method you use below.** A required status check
 > that has never reported blocks every merge — GitHub shows it as *Expected —
-> waiting for status* — and *Include administrators* removes the override that
-> would let you merge anyway. Protect a repo that has no CI yet and you lock
-> yourself out of your own `main`.
+> waiting for status* — and *Do not allow bypassing the above settings*
+> (`enforce_admins` in the API) removes the override that would let you merge
+> anyway. Protect a repo that has no CI yet and you lock yourself out of your
+> own `main`.
 >
 > 1. Add the workflow that produces `validate` and push it on a branch.
 > 2. Open a PR and watch `validate` go green at least once, so you know the
@@ -1482,7 +1483,7 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 | Require approvals | **0 (none)** | No one else to approve — CI is your gate |
 | Require status checks to pass | ✓ Enabled | CI must be green |
 | Require branches to be up to date | ✓ Enabled | No stale merges |
-| Include administrators | **✓ Enabled** | Safe at 0 approvals — but set CI up first, see below |
+| Do not allow bypassing the above settings | **✓ Enabled** | Safe at 0 approvals — but set CI up first, see below |
 
 **Team Settings (2+ developers):**
 
@@ -1492,7 +1493,7 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 | Require approvals | 1+ (your choice) | Human must approve before merge |
 | Require status checks to pass | ✓ Enabled | CI must be green |
 | Require branches to be up to date | ✓ Enabled | No stale merges |
-| Include administrators | ✓ Enabled | No one bypasses the rules |
+| Do not allow bypassing the above settings | ✓ Enabled | No one bypasses the rules |
 
 **How to enable (UI):**
 1. Go to: `Settings > Branches > Add rule`

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1471,7 +1471,7 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 | Require approvals | **0 (none)** | No one else to approve — CI is your gate |
 | Require status checks to pass | ✓ Enabled | CI must be green |
 | Require branches to be up to date | ✓ Enabled | No stale merges |
-| Include administrators | **✗ Disabled** | You're the only admin — this locks you out |
+| Include administrators | **✓ Enabled** | With 0 approvals it cannot lock you out — see below |
 
 **Team Settings (2+ developers):**
 
@@ -1500,11 +1500,45 @@ gh api repos/OWNER/REPO/branches/main/protection --method PUT --input - << 'EOF'
     "strict": true,
     "contexts": ["validate"]
   },
-  "enforce_admins": false,
-  "required_pull_request_reviews": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0
+  },
   "restrictions": null
 }
 EOF
+```
+
+**Why `enforce_admins: true` for a solo dev.** The usual reason to leave it off
+is that it locks the only admin out. That is true when a review is required —
+GitHub refuses self-approval, so an admin with `required_approving_review_count:
+1` and nobody else around cannot merge anything. With **0** approvals there is
+nothing to be locked out of: you owe a green `validate` and an up-to-date
+branch, which you were waiting for anyway. This repo turned `enforce_admins` on
+in August 2026 with approvals at 0 and nothing locked up.
+
+**Why `required_approving_review_count: 0` and not `null`.** `null` does not
+mean "a PR with no approvals" — it means **no pull request is required at
+all**, which is a different and much weaker setting. The `0` form requires the
+PR and asks nobody to approve it. This repo's own `main` still has `null`,
+which is why a direct push to it is possible today — see the next paragraph and
+#679.
+
+**What this does NOT do, and the ordering matters:** if you leave
+`required_pull_request_reviews` as `null`, admin enforcement does **not** stop a
+direct push to `main`. A commit that already carries a green `validate` lands —
+push a branch, let CI run, then push that same SHA to `main`. Check runs attach
+to commits rather than branches. Only a *fresh* commit is rejected. Requiring
+the pull request is what closes that, not `enforce_admins`.
+
+**Changing one field later:** `PUT .../protection` **replaces the entire
+protection object**, so re-running one of these recipes to adjust a single
+setting silently drops everything absent from your payload — including any
+`checks[].app_id` pin. To change one field, use its sub-endpoint:
+
+```bash
+gh api -X POST repos/OWNER/REPO/branches/main/protection/enforce_admins   # on
+gh api -X DELETE repos/OWNER/REPO/branches/main/protection/enforce_admins # off
 ```
 
 **How to enable (CLI — team):**

--- a/CLAUDE_CODE_SDLC_WIZARD.md
+++ b/CLAUDE_CODE_SDLC_WIZARD.md
@@ -1471,7 +1471,7 @@ For Claude to be effective at SDLC enforcement, your project should have these d
 | Require approvals | **0 (none)** | No one else to approve — CI is your gate |
 | Require status checks to pass | ✓ Enabled | CI must be green |
 | Require branches to be up to date | ✓ Enabled | No stale merges |
-| Include administrators | **✓ Enabled** | With 0 approvals it cannot lock you out — see below |
+| Include administrators | **✓ Enabled** | Safe at 0 approvals — but set CI up first, see below |
 
 **Team Settings (2+ developers):**
 


### PR DESCRIPTION
Closes #686.

## The defect

`CLAUDE_CODE_SDLC_WIZARD.md` **Step 0.0** told a new consumer to protect `main`
with a required `validate` check before their repo had any CI. Follow the page
in order and **you lock yourself out of your own `main`**: a required status
check that has never reported blocks every merge — GitHub shows it as *Expected
— waiting for status* — and enabling the admin-bypass control removes the
override that would let you merge anyway.

This shipped. It is in the released package today.

## What changed

**The ordering rule, hoisted to the top of the section.** Add the workflow that
produces `validate`, watch it go green once, *then* apply protection. This
started life inside the CLI subsection, where a reader following the UI path
never reached it — round 3 caught that and it moved.

**The solo CLI recipe is corrected.** It previously shipped
`enforce_admins: false` with `required_pull_request_reviews: null`. It now ships
`enforce_admins: true` with `required_approving_review_count: 0`, plus caveats
covering why `0` and not `null` (absent means *no PR required at all*), what
admin enforcement does **not** do (a commit already carrying a green check still
lands), that a green `validate` is not inherently trustworthy because a
candidate branch can redefine the workflow, and that `PUT .../protection`
replaces the whole object.

**Six GitHub UI labels corrected against the current docs.** Round 4 found one;
round 5 swept the same source across the section and found four more of the
identical class, plus the wrong terminal button:

| Shipped | Current |
|---|---|
| Include administrators | Do not allow bypassing the above settings |
| Require pull request before merging | Require **a** pull request before merging |
| Require status checks to pass | Require status checks to pass **before merging** |
| Require branches to be up to date | Require branches to be up to date **before merging** |
| Require CODEOWNERS review | Require review from Code Owners |
| `Save changes` ends the Add rule flow | `Create` does; `Save changes` is the edit flow |

## Review

Five Sol rounds: 3 findings → 1 → 1 → 1 → **CERTIFIED 99**. Every finding was
P1 or P2 and every one was mine.

The recurring defect class across this branch was **a claim repaired in one
place and left false in another** — three separate instances here: a sentence,
then a table cell that still carried the falsified claim after the prose was
fixed, then an entire procedure sitting in the wrong section. Round 3's
technique is what caught the third: assume the class recurred and sweep the
whole file rather than re-reading the diff.

Round 4 is the one worth recording. The reviewer said a UI label was wrong. I
did not argue and did not concede on authority — I fetched GitHub's
documentation and confirmed it. Round 5 then applied that same fetch across the
section and found four more. **Fetching beat arguing, and re-running the fetch
beat trusting the first pass.**

## Verification

- Full CI sweep: **81 suites, 0 failures**, on `07c04ee`, clean tree
  (`tests/e2e/run-simulation.sh` excluded locally — it burns live quota).
- `test-doc-consistency.sh`: 137 passed, 0 failed.

## Known gap, filed not hidden

Sol raised, and it remains open: **this recipe has never been executed.** Every
claim here was verified by reading GitHub's documentation, not by running the
procedure against a live repository. For something we instruct consumers to
execute, that is the weaker form of verification — see #573, *don't ship a
command you haven't run*.

Merging anyway is deliberate: what ships today walks a new consumer into a
lockout, so holding this for a live trial keeps the harmful version in the
package. **The disposable-repo trial is #692, and it gates the next tag.** It is filed
as its own issue rather than left as a comment here, so that merging this PR
cannot bury it.
