### PR TITLE
docs: document the opus-4.6 dist-tag — pinned pre-Opus-5 fallback (#689 7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the SDLC Wizard.
 
 > **Note:** This changelog is for humans to read. Don't manually apply these changes - just run the wizard ("Check for SDLC wizard updates") and it handles everything automatically.
 
+> **Registry note, 2026-08-26 — `opus-4.6` dist-tag (not a release).** The npm
+> tag `opus-4.6` now points at **v1.87.0**, the last release published before
+> Opus 5 entered this repo (Opus 5 became the Setup A default in v1.88.0).
+> As of this note, `npm install agentic-sdlc-wizard@opus-4.6` resolves to that
+> release; v1.87.0's published contents are immutable, while the tag itself is
+> a mutable pointer — pin `@1.87.0` to guarantee the version.
+> Its known-goodness is **recollection, not a recorded test** — the
+> lifecycle canary that would upgrade that claim is tracked in
+> [#689](https://github.com/BaseInfinity/claude-sdlc-harness/issues/689). No
+> package contents changed; this entry documents registry state only.
+> Observed at tagging time: `npm view agentic-sdlc-wizard dist-tags` →
+> `{ latest: '1.99.2', 'opus-4.6': '1.87.0' }`.
+
 ## [1.99.2] - 2026-08-17
 
 ### Evidence now binds to what was reviewed, and the docs stopped claiming what nobody measured

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ npm install -g agentic-sdlc-wizard
 sdlc-wizard init
 ```
 
+**Pinned fallback — the last pre-Opus-5 release:**
+```bash
+npm install -g agentic-sdlc-wizard@opus-4.6
+```
+The `opus-4.6` dist-tag currently points at **v1.87.0** (2026-07-14), the
+last release cut before Opus 5 entered this repo, from the era when the
+recommended lanes were built around Opus 4.6 / Sonnet 5. The published
+v1.87.0 package contents are immutable; the dist-tag itself is a mutable
+registry pointer, so to guarantee that exact version regardless of where the
+tag may later point, pin it directly: `agentic-sdlc-wizard@1.87.0`.
+**Honest label:** its
+known-goodness is the maintainer's recollection of daily use, not a recorded
+end-to-end test — a lifecycle canary is tracked in
+[#689](https://github.com/BaseInfinity/claude-sdlc-harness/issues/689), and
+this label upgrades to "verified" only when that canary's verdict is recorded
+there. Verified on 2026-08-26: `npm install agentic-sdlc-wizard@opus-4.6`
+resolves and installs 1.87.0.
+
 **Manual (advanced — partial, not an escape hatch):** Download `CLAUDE_CODE_SDLC_WIZARD.md` to your project and tell Claude `Run the SDLC wizard setup`. This skips the live-session auto-invoke and generates your bespoke `CLAUDE.md`, `SDLC.md`, `TESTING.md` and `ARCHITECTURE.md`. **It does not give you a working install.** The document no longer contains the SDLC skill — Step 6 installs it by running the CLI (GH #513) — and only 2 of the 8 hooks have hand-typed templates here. So this path still needs `npx`; there is no npx-free route to a complete install. The default human path is `npx init` → restart CC → first-prompt auto-setup.
 </details>
 

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1703,10 +1703,12 @@ test_readme_reviewer_is_gpt56() {
     local F="$REPO_ROOT/README.md"
     if [ ! -f "$F" ]; then fail "README.md not found"; return; fi
     local bad=""
-    # L130 is the fallback-chain line: must name "5\.6" AND BOTH Sol and Terra.
-    # (Re-pinned 2026-08-16 by #544's frontier-model banner, which shifted every
-    # line below it by 4. Position pins again, not content — see #659.)
-    bad="$bad$(_check_line_has_and_lacks "$F" 130 "5\.6,Sol,Terra" "5\.5" "5\.4")"
+    # L148 is the fallback-chain line: must name "5\.6" AND BOTH Sol and Terra.
+    # (Re-pinned 2026-08-16 by #544's frontier-model banner, then again
+    # 2026-08-26 by the opus-4.6 dist-tag install block — twice in one PR,
+    # once per review round that grew the block. Position pins again, not
+    # content — see #659, which this PR is fresh evidence for.)
+    bad="$bad$(_check_line_has_and_lacks "$F" 148 "5\.6,Sol,Terra" "5\.5" "5\.4")"
     # Every OTHER line naming a GPT-5.x reviewer must name 5.6, by CONTENT.
     # This replaced position pins on lines 193-195 when the model-selection
     # research moved to AI_SETUP_LANES.md (#659 asked for exactly this: the


### PR DESCRIPTION
Executes #689 step 7.1 (the dist-tag itself was run by the maintainer with OTP; this PR documents it).

**Registry state, observed:** `npm view agentic-sdlc-wizard dist-tags` → `{ latest: '1.99.2', 'opus-4.6': '1.87.0' }`; clean-dir `npm install agentic-sdlc-wizard@opus-4.6` installs 1.87.0.

- README: pinned-fallback install block — tag meaning, last-pre-Opus-5 status, contents-vs-pointer immutability distinction, and the #689 caveat verbatim (recollection, not a recorded test; upgrades only on a recorded canary verdict).
- CHANGELOG: dated registry note above the version history, explicitly "not a release."
- tests/test-doc-consistency.sh: openly-rescoped enabling change — the reviewer-model check is position-pinned (#659) and moved 130→148 across the two README insertions. It re-pinned twice in one PR (once per review round that grew the block), which is fresh evidence for #659.

**Review:** both seats blind round 1 → Codex P1 (immutability overclaim), Fable P2 (future-dated stamps) + P3 (= Codex's P1, independent). All repaired; round 2 dual CERTIFIED (Codex 99, zero findings; Fable, zero findings) on tree `cddea06`.
