### PR TITLE
docs(readme): stability lanes — opus-4.6 stable, Opus-5 era experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,37 @@ A **self-evolving Software Development Life Cycle (SDLC) enforcement system for 
 
 **Built on 15+ years of software engineering and founding engineering experience** — battle-tested patterns from real production systems, baked into an AI agent that follows tried-and-true software quality practices so you don't have to enforce them manually.
 
-> **Built and validated on frontier models.** This harness is developed against **Opus 5** as the driver, **Fable 5** as the design authority, and **GPT-5.6 Sol** as the cross-model adversarial check. That is the only configuration behind which there is cycle data from real use.
+> **The experimental lane (v1.88.0+) is built and validated on frontier models.** It is developed against **Opus 5** as the driver, **Fable 5** as the design authority, and **GPT-5.6 Sol** as the cross-model adversarial check. That is the only configuration behind which the experimental lane has cycle data from real use. (The stable lane below has its own pairing.)
 >
-> **Behavior on earlier or smaller drivers is unmeasured.** Not "degraded," not "should still work" — nobody has run it and measured. The harness leans on the driver to hold a long plan, refuse its own shortcuts, and escalate when uncertain; how much of that survives on a weaker model is exactly the thing no one here has data on. If you run it elsewhere and measure something, that result is worth more than this paragraph.
+> **Experimental-lane behavior on earlier or smaller drivers is unmeasured.** Not "degraded," not "should still work" — nobody has run it and measured. The harness leans on the driver to hold a long plan, refuse its own shortcuts, and escalate when uncertain; how much of that survives on a weaker model is exactly the thing no one here has data on. If you run it elsewhere and measure something, that result is worth more than this paragraph.
 
 > **Built for Claude Code.** Using OpenAI's Codex CLI instead? Check out [`codex-sdlc-wizard`](https://github.com/BaseInfinity/codex-sdlc-wizard). Need privacy-first / any-backend (local Ollama, Azure OpenAI, hosted OSS)? See [`opencode-sdlc-wizard`](https://github.com/BaseInfinity/opencode-sdlc-wizard). ([Full ecosystem](#xdlc-ecosystem-sibling-projects).)
+
+> **Stability lanes.** The **most stable line is `opus-4.6`** — v1.87.0, the last
+> release before Opus 5 entered this repo, from the era the maintainer drove it
+> daily on Opus 4.6 (that known-goodness is recollection, being converted to
+> verified in [#689](https://github.com/BaseInfinity/claude-sdlc-harness/issues/689)).
+> The stable lane pairs v1.87.0 with the **Opus 4.6 driver it was built for**
+> (`/model claude-opus-4-6`, `/effort max`) — sessions on this pin have been
+> observed at a **200k context window**; a verified 1M launch path for 4.6 is an
+> open item in [#689](https://github.com/BaseInfinity/claude-sdlc-harness/issues/689).
+> Everything after it — v1.88.0+, the Opus 5 era, **including `@latest`** — is
+> **experimental**: reworked and validated in the open. Follow the validation lane:
+> [#689](https://github.com/BaseInfinity/claude-sdlc-harness/issues/689),
+> [#694](https://github.com/BaseInfinity/claude-sdlc-harness/issues/694),
+> [#697](https://github.com/BaseInfinity/claude-sdlc-harness/issues/697) and the
+> findings filed from #697
+> ([#698](https://github.com/BaseInfinity/claude-sdlc-harness/issues/698)–[#702](https://github.com/BaseInfinity/claude-sdlc-harness/issues/702)).
+> Stable-lane install — pinned end-to-end, never `@latest` (see
+> [#699](https://github.com/BaseInfinity/claude-sdlc-harness/issues/699)):
+> ```bash
+> npm install -g agentic-sdlc-wizard@opus-4.6
+> npx -y agentic-sdlc-wizard@opus-4.6 init
+> ```
+> Known defect on **both** lanes: setup does not auto-invoke on a brand-new
+> project ([#698](https://github.com/BaseInfinity/claude-sdlc-harness/issues/698))
+> — run it manually on first launch: type `/` plus the skill name, which is
+> `setup-wizard` on the stable lane and `claude-setup-wizard` on latest.
 
 ## Install
 
@@ -18,8 +44,8 @@ Run from your terminal or from inside Claude Code (`!` prefix):
 ```bash
 npx -y agentic-sdlc-wizard@latest init
 ```
-The `@latest` pin forces npm to fetch the newest version. Without it, `npx` may serve a stale CLI from your local cache (#358); `init` also nudges if it detects a gap.
-Then start (or restart) Claude Code — type `/exit` then `claude` to reload hooks. Setup auto-invokes on first prompt — Claude reads the wizard doc, scans your project, and generates bespoke CLAUDE.md, SDLC.md, TESTING.md, and ARCHITECTURE.md. No manual commands needed.
+This is the **experimental lane** — the Opus-5-era latest (see *Stability lanes* above; the stable-lane commands are there). The `@latest` pin forces npm to fetch the newest version. Without it, `npx` may serve a stale CLI from your local cache (#358); `init` also nudges if it detects a gap.
+Then start (or restart) Claude Code — type `/exit` then `claude` to reload hooks. Setup is meant to auto-invoke on first prompt — Claude reads the wizard doc, scans your project, and generates bespoke CLAUDE.md, SDLC.md, TESTING.md, and ARCHITECTURE.md. **Known defect:** on a brand-new project the auto-invoke does not fire ([#698](https://github.com/BaseInfinity/claude-sdlc-harness/issues/698)) — run the setup skill manually as described in *Stability lanes* above.
 
 <details>
 <summary>Alternative install methods</summary>
@@ -52,7 +78,7 @@ npm install -g agentic-sdlc-wizard
 sdlc-wizard init
 ```
 
-**Pinned fallback — the last pre-Opus-5 release:**
+**Stable lane — the last pre-Opus-5 release:**
 ```bash
 npm install -g agentic-sdlc-wizard@opus-4.6
 ```

--- a/tests/test-doc-consistency.sh
+++ b/tests/test-doc-consistency.sh
@@ -1703,12 +1703,13 @@ test_readme_reviewer_is_gpt56() {
     local F="$REPO_ROOT/README.md"
     if [ ! -f "$F" ]; then fail "README.md not found"; return; fi
     local bad=""
-    # L148 is the fallback-chain line: must name "5\.6" AND BOTH Sol and Terra.
-    # (Re-pinned 2026-08-16 by #544's frontier-model banner, then again
-    # 2026-08-26 by the opus-4.6 dist-tag install block — twice in one PR,
-    # once per review round that grew the block. Position pins again, not
-    # content — see #659, which this PR is fresh evidence for.)
-    bad="$bad$(_check_line_has_and_lacks "$F" 148 "5\.6,Sol,Terra" "5\.5" "5\.4")"
+    # L174 is the fallback-chain line: must name "5\.6" AND BOTH Sol and Terra.
+    # (Re-pinned 2026-08-16 by #544's frontier-model banner, twice on
+    # 2026-08-26 by the opus-4.6 dist-tag install block, and twice more
+    # the same day by the stability-lanes banner and its review repairs —
+    # a position pin, not content — see #659, which keeps accumulating
+    # evidence.)
+    bad="$bad$(_check_line_has_and_lacks "$F" 174 "5\.6,Sol,Terra" "5\.5" "5\.4")"
     # Every OTHER line naming a GPT-5.x reviewer must name 5.6, by CONTENT.
     # This replaced position pins on lines 193-195 when the model-selection
     # research moved to AI_SETUP_LANES.md (#659 asked for exactly this: the


### PR DESCRIPTION
## What

README now declares **stability lanes** at the top: the most stable line is the `opus-4.6` dist-tag (v1.87.0), and the Opus-5 era (v1.88.0+ / `@latest`) is **experimental**, with the validation-lane issues (#689, #694, #697 and findings #698–#702) linked where the lanes are declared. Owner directive, #689 arc.

- Stable-lane install block in the banner, pinned end-to-end (never `@latest` — #699)
- #698 disclosed at both places the old auto-invoke promise lived, with a **verified** manual invocation per lane
- The 200k observed context window on the explicit 4.6 pin disclosed next to the pairing recommendation (#629)
- Frontier-models blockquote scoped to the experimental lane (it contradicted the banner)
- "Pinned fallback" heading renamed "Stable lane"
- Reviewer-line position pin re-pinned 148→174 (#659 evidence, moves three and four)

## Evidence (#573: every shipped command was run)

- `npm install -g agentic-sdlc-wizard@opus-4.6` → `sdlc-wizard --version` 1.87.0, global restored to 1.88.0 after
- Plain `npx -y agentic-sdlc-wizard@opus-4.6 init` in a pristine dir: completed
- `claude -p "/setup-wizard verify-only"` (1.87.0) and `claude -p "/claude-setup-wizard verify-only"` (1.99.2): both ran the skill
- `tests/test-doc-consistency.sh`: 137 passed / 0 failed

## Review

Three rounds, dual reviewers. Round 1: Sol CERTIFIED zero findings; Fable two in-card P1s (banner contradicted the blockquote above it; manual-setup instruction had never been run). Round 2: repairs + both-lane execution; Fable resolved both, raised one in-card P2 (undisclosed 200k trap). Round 3: disclosure clause added; **Sol CERTIFIED/SOUND/99, Fable CERTIFIED/SOUND/95, both bound to candidate tree `63f16e38`**. Residual P3 routed to #699; #703 filed from a side finding.
